### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,6 @@ python-dateutil>=2.8.2
 python-dotenv>=0.19.0,<2.0.0
 pydantic>=1.10.0,<3.0.0
 packaging>=21.0
+
+# Websockets dependencies quick fix
+websockets>=15.0.1


### PR DESCRIPTION
Proposed fix for missing Websockets dependencies in some environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added the websockets package (version 15.0.1 or higher) as a dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->