### PR TITLE
Update logging.py

### DIFF
--- a/src/wazuh_mcp_server/utils/logging.py
+++ b/src/wazuh_mcp_server/utils/logging.py
@@ -44,7 +44,7 @@ class StructuredFormatter(logging.Formatter):
     def format(self, record):
         """Format log record as structured JSON."""
         log_entry = {
-            'timestamp': datetime.now(datetime.timezone.utc).isoformat(),
+            'timestamp': datetime.now().isoformat(),
             'level': record.levelname,
             'logger': record.name,
             'message': record.getMessage(),


### PR DESCRIPTION
logging error in ubuntu 22.04:

  File "/opt/mcp/Wazuh-MCP-Server/src/wazuh_mcp_server/utils/logging.py", line 47, in format
    'timestamp': datetime.now(datetime.timezone.utc).isoformat(),
                              ^^^^^^^^^^^^^^^^^

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated log timestamps to use local time without timezone information, replacing the previous UTC ISO format. This changes how timestamps appear in logs while leaving all other log fields and overall formatting unchanged. If you rely on UTC or timezone-aware parsing in monitoring or analytics tools, adjust configurations accordingly. No other user-visible behavior or interfaces are affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->