### PR TITLE
Add MCP protocol 2025-06-18 to supported versions for Windsurf compatibility

### DIFF
--- a/src/wazuh_mcp_server/server.py
+++ b/src/wazuh_mcp_server/server.py
@@ -8,7 +8,7 @@ Production-ready with Streamable HTTP and legacy SSE transport, authentication, 
 # MCP Protocol Version Support
 # Latest: 2025-11-25, also supports backwards compatibility with older versions
 MCP_PROTOCOL_VERSION = "2025-11-25"
-SUPPORTED_PROTOCOL_VERSIONS = ["2025-11-25", "2025-03-26", "2024-11-05"]
+SUPPORTED_PROTOCOL_VERSIONS = ["2025-11-25", "2025-06-18", "2025-03-26", "2024-11-05"]
 
 # Production Constants
 SESSION_TIMEOUT_MINUTES = 30


### PR DESCRIPTION
# PR Title

Add MCP protocol `2025-06-18` to supported versions for Windsurf compatibility

## Summary

- Adds `2025-06-18` to `SUPPORTED_PROTOCOL_VERSIONS` in MCP protocol negotiation.
- Keeps `MCP_PROTOCOL_VERSION` default as `2025-11-25` (no behavior change for latest-compatible clients).
- Fixes Windsurf initialization failures where client startup can fail with unsupported protocol version and then fall back to SSE timeout.

## Details

### Problem

Windsurf failed to initialize against this MCP server even when:
- server health checks were passing,
- `/mcp` endpoint was reachable,
- authentication and networking were correct.

Observed behavior was:
1. Streamable HTTP connection attempt to `/mcp`
2. Initialize failure with unsupported protocol version (`2025-11-25`)
3. Client fallback to SSE
4. Timeout waiting for endpoint

### Root cause

`SUPPORTED_PROTOCOL_VERSIONS` did not include `2025-06-18`, which Windsurf requires in this environment.

When protocol negotiation encountered unsupported versions from the client/server perspective, Windsurf initialization failed before tools could be used.

### Change made

In `src/wazuh_mcp_server/server.py`:

**Before**

```python
MCP_PROTOCOL_VERSION = "2025-11-25"
SUPPORTED_PROTOCOL_VERSIONS = ["2025-11-25", "2025-03-26", "2024-11-05"]
```

**After**

```python
MCP_PROTOCOL_VERSION = "2025-11-25"
SUPPORTED_PROTOCOL_VERSIONS = ["2025-11-25", "2025-06-18", "2025-03-26", "2024-11-05"]
```

### Why this approach

- Minimal, low-risk compatibility patch.
- Preserves default behavior for clients that already support `2025-11-25`.
- Adds Windsurf interoperability without removing existing protocol support.

## Test plan

1. Start server with patched code.
2. Configure Windsurf remote MCP with:
   - `serverUrl: http://127.0.0.1:3003/mcp` (or remote `/mcp` endpoint)
   - optional header `MCP-Protocol-Version: 2025-03-26`
3. Verify server initializes in Windsurf (no unsupported-protocol error).
4. Verify `tools/list` succeeds.
5. Verify `tools/call` succeeds (e.g., `get_wazuh_running_agents`).

## Validation results

- Server health endpoint responded successfully.
- MCP initialize succeeded with compatible protocol negotiation.
- `tools/list` succeeded and returned tool catalog.
- `get_wazuh_running_agents` returned active agents.
- Prior error path (`unsupported protocol version: "2025-11-25"` + SSE timeout) no longer blocks operation when `2025-06-18` is supported.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for MCP protocol version 2025-06-18 to improve compatibility with newer protocol implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->