### PR TITLE
fix: plain-HTTP indexer support and relative timestamps (#78, #73)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,11 @@ WAZUH_VERIFY_SSL=true
 # WAZUH_INDEXER_PORT=9200
 # WAZUH_INDEXER_USER=admin
 # WAZUH_INDEXER_PASS=admin
+# Transport scheme for the indexer. Defaults to HTTPS. Set to false for a plain-HTTP
+# OpenSearch node (you can also just put http:// in WAZUH_INDEXER_HOST).
+# WAZUH_INDEXER_SSL=true
+# Verify the indexer's TLS certificate. Set to false for self-signed certs in dev.
+# WAZUH_INDEXER_VERIFY_SSL=true
 
 # === Session Storage (Serverless Ready) ===
 # Optional Redis URL for serverless/multi-instance deployments

--- a/src/wazuh_mcp_server/api/wazuh_client.py
+++ b/src/wazuh_mcp_server/api/wazuh_client.py
@@ -57,8 +57,9 @@ class WazuhClient:
                 port=config.wazuh_indexer_port,
                 username=config.wazuh_indexer_user,
                 password=config.wazuh_indexer_pass,
-                verify_ssl=config.verify_ssl,
+                verify_ssl=getattr(config, "wazuh_indexer_verify_ssl", config.verify_ssl),
                 timeout=config.request_timeout_seconds,
+                use_ssl=getattr(config, "wazuh_indexer_ssl", True),
             )
             logger.info(f"WazuhIndexerClient configured for {config.wazuh_indexer_host}:{config.wazuh_indexer_port}")
         else:

--- a/src/wazuh_mcp_server/api/wazuh_indexer.py
+++ b/src/wazuh_mcp_server/api/wazuh_indexer.py
@@ -37,7 +37,11 @@ class WazuhIndexerClient:
         password: Optional[str] = None,
         verify_ssl: bool = True,
         timeout: int = 30,
+        use_ssl: bool = True,
     ):
+        # Detect scheme from the host prefix before stripping it; an explicit http://
+        # prefix wins over use_ssl so an OpenSearch node served over plain HTTP works.
+        detected_scheme = self._detect_scheme(host)
         # Normalize host (strip protocol if user included it)
         self.host = self._normalize_host(host)
         self.port = port
@@ -45,6 +49,7 @@ class WazuhIndexerClient:
         self.password = password
         self.verify_ssl = verify_ssl
         self.timeout = timeout
+        self.scheme = detected_scheme or ("https" if use_ssl else "http")
         self.client: Optional[httpx.AsyncClient] = None
         self._initialized = False
         self._init_lock = asyncio.Lock()
@@ -61,10 +66,22 @@ class WazuhIndexerClient:
                 break
         return host.rstrip("/")
 
+    @staticmethod
+    def _detect_scheme(host: str) -> Optional[str]:
+        """Return 'http' or 'https' if the host includes an explicit scheme, else None."""
+        if not host:
+            return None
+        lowered = host.lower()
+        if lowered.startswith("http://"):
+            return "http"
+        if lowered.startswith("https://"):
+            return "https"
+        return None
+
     @property
     def base_url(self) -> str:
         """Get the base URL for the Wazuh Indexer."""
-        return f"https://{self.host}:{self.port}"
+        return f"{self.scheme}://{self.host}:{self.port}"
 
     async def initialize(self):
         """Initialize the HTTP client and circuit breaker."""
@@ -104,7 +121,7 @@ class WazuhIndexerClient:
             )
 
         self._initialized = True
-        logger.info(f"WazuhIndexerClient initialized for {self.host}:{self.port}")
+        logger.info(f"WazuhIndexerClient initialized for {self.base_url} (verify_ssl={self.verify_ssl})")
 
     async def close(self):
         """Close the HTTP client."""

--- a/src/wazuh_mcp_server/config.py
+++ b/src/wazuh_mcp_server/config.py
@@ -74,6 +74,8 @@ class WazuhConfig:
     wazuh_indexer_port: int = 9200
     wazuh_indexer_user: Optional[str] = None
     wazuh_indexer_pass: Optional[str] = None
+    wazuh_indexer_ssl: bool = True  # Use HTTPS for the indexer (set False for plain-HTTP OpenSearch nodes)
+    wazuh_indexer_verify_ssl: bool = True  # Verify the indexer's TLS certificate
 
     # Transport settings
     mcp_transport: str = "http"  # Default to HTTP/SSE mode
@@ -194,6 +196,7 @@ class ServerConfig:
     WAZUH_INDEXER_PORT: int = 9200
     WAZUH_INDEXER_USER: str = ""
     WAZUH_INDEXER_PASS: str = ""
+    WAZUH_INDEXER_SSL: bool = True
     WAZUH_INDEXER_VERIFY_SSL: bool = True
 
     # Logging
@@ -218,6 +221,15 @@ class ServerConfig:
         log_level = os.getenv("LOG_LEVEL", "INFO").upper()
         if log_level not in ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"):
             log_level = "INFO"
+
+        # Indexer scheme: honor an explicit WAZUH_INDEXER_SSL, otherwise infer from the
+        # host prefix (http:// -> plain HTTP). Defaults to HTTPS when no scheme is given.
+        indexer_host_raw = os.getenv("WAZUH_INDEXER_HOST", "")
+        indexer_ssl_env = os.getenv("WAZUH_INDEXER_SSL")
+        if indexer_ssl_env is not None:
+            indexer_ssl = indexer_ssl_env.lower() == "true"
+        else:
+            indexer_ssl = not indexer_host_raw.strip().lower().startswith("http://")
 
         return cls(
             MCP_HOST=os.getenv("MCP_HOST", "0.0.0.0"),
@@ -246,10 +258,11 @@ class ServerConfig:
             WAZUH_VERIFY_SSL=os.getenv("WAZUH_VERIFY_SSL", "true").lower() == "true",
             WAZUH_ALLOW_SELF_SIGNED=os.getenv("WAZUH_ALLOW_SELF_SIGNED", "true").lower() == "true",
             # Wazuh Indexer settings (for vulnerability tools in Wazuh 4.8.0+)
-            WAZUH_INDEXER_HOST=normalize_host(os.getenv("WAZUH_INDEXER_HOST", "")),
+            WAZUH_INDEXER_HOST=normalize_host(indexer_host_raw),
             WAZUH_INDEXER_PORT=validate_port(os.getenv("WAZUH_INDEXER_PORT", "9200"), "WAZUH_INDEXER_PORT"),
             WAZUH_INDEXER_USER=os.getenv("WAZUH_INDEXER_USER", ""),
             WAZUH_INDEXER_PASS=os.getenv("WAZUH_INDEXER_PASS", ""),
+            WAZUH_INDEXER_SSL=indexer_ssl,
             WAZUH_INDEXER_VERIFY_SSL=os.getenv("WAZUH_INDEXER_VERIFY_SSL", "true").lower() == "true",
             LOG_LEVEL=log_level,
         )

--- a/src/wazuh_mcp_server/security.py
+++ b/src/wazuh_mcp_server/security.py
@@ -49,6 +49,9 @@ VALID_COMPLIANCE_FRAMEWORKS = {"PCI-DSS", "HIPAA", "SOX", "GDPR", "NIST"}
 AGENT_ID_PATTERN = re.compile(r"^[0-9]{1,5}$")  # Wazuh agent IDs: 0 (manager) through 99999
 RULE_ID_PATTERN = re.compile(r"^[0-9]{1,6}$")  # Rule IDs are numeric
 ISO_TIMESTAMP_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:?\d{2})?)?$")
+# OpenSearch/Elasticsearch date math, e.g. "now", "now-24h", "now-7d/d", "now-1h-30m".
+# These pass straight through to the indexer range query, which evaluates them natively.
+DATE_MATH_PATTERN = re.compile(r"^now([+-]\d+[yMwdhHms])*(/[yMwdhHms])?$")
 # Use ipaddress module for proper validation instead of regex
 IP_ADDRESS_PATTERN = None  # Replaced by _is_valid_ip() function
 HASH_PATTERN = re.compile(r"^[a-fA-F0-9]{32,128}$")  # MD5 to SHA-512
@@ -175,7 +178,11 @@ def validate_agent_status(value: Any, param_name: str = "status") -> Optional[st
 
 
 def validate_timestamp(value: Any, required: bool = False, param_name: str = "timestamp") -> Optional[str]:
-    """Validate ISO 8601 timestamp format."""
+    """Validate an ISO 8601 timestamp or OpenSearch relative date math (e.g. 'now-24h').
+
+    Relative expressions are common from LLM clients and are passed straight through to
+    the indexer range query, which evaluates date math natively.
+    """
     if value is None:
         if required:
             raise ToolValidationError(param_name, "is required")
@@ -188,12 +195,20 @@ def validate_timestamp(value: Any, required: bool = False, param_name: str = "ti
             raise ToolValidationError(param_name, "cannot be empty")
         return None
 
-    if not ISO_TIMESTAMP_PATTERN.match(timestamp):
-        raise ToolValidationError(
-            param_name, f"invalid ISO 8601 format '{timestamp}'", "Use format: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ"
-        )
+    # Accept OpenSearch date math (e.g. now-24h). Normalize the leading "now" keyword to
+    # lowercase since the indexer requires it; unit case (h/H, m/M) is preserved as-is.
+    normalized = ("now" + timestamp[3:]) if timestamp[:3].lower() == "now" else timestamp
+    if DATE_MATH_PATTERN.match(normalized):
+        return normalized
 
-    return timestamp
+    if ISO_TIMESTAMP_PATTERN.match(timestamp):
+        return timestamp
+
+    raise ToolValidationError(
+        param_name,
+        f"invalid timestamp '{timestamp}'",
+        "Use ISO 8601 (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ) or relative date math (e.g. now-24h, now-7d/d)",
+    )
 
 
 def validate_indicator(value: Any, indicator_type: str, param_name: str = "indicator") -> str:

--- a/src/wazuh_mcp_server/server.py
+++ b/src/wazuh_mcp_server/server.py
@@ -541,6 +541,8 @@ wazuh_config = WazuhConfig(
     wazuh_indexer_port=config.WAZUH_INDEXER_PORT,
     wazuh_indexer_user=config.WAZUH_INDEXER_USER if config.WAZUH_INDEXER_USER else None,
     wazuh_indexer_pass=config.WAZUH_INDEXER_PASS if config.WAZUH_INDEXER_PASS else None,
+    wazuh_indexer_ssl=config.WAZUH_INDEXER_SSL,
+    wazuh_indexer_verify_ssl=config.WAZUH_INDEXER_VERIFY_SSL,
 )
 
 # Initialize Wazuh client
@@ -1300,8 +1302,8 @@ async def handle_tools_list(params: Dict[str, Any], session: MCPSession) -> Dict
                     "rule_id": {"type": "string", "description": "Filter by specific rule ID"},
                     "level": {"type": "string", "description": "Filter by alert level (e.g., '12', '10+')"},
                     "agent_id": {"type": "string", "description": "Filter by agent ID"},
-                    "timestamp_start": {"type": "string", "description": "Start timestamp (ISO format)"},
-                    "timestamp_end": {"type": "string", "description": "End timestamp (ISO format)"},
+                    "timestamp_start": {"type": "string", "description": "Start timestamp — ISO 8601 (YYYY-MM-DDTHH:MM:SSZ) or relative date math (e.g. now-24h, now-7d)"},
+                    "timestamp_end": {"type": "string", "description": "End timestamp — ISO 8601 (YYYY-MM-DDTHH:MM:SSZ) or relative date math (e.g. now, now-1h)"},
                     "compact": {
                         "type": "boolean",
                         "default": True,


### PR DESCRIPTION
Fixes two reported bugs. Both changes are backwards compatible (defaults stay HTTPS + ISO 8601).

## #78 — HTTP Wazuh Indexer URLs were forced to HTTPS internally
`WazuhIndexerClient.base_url` hardcoded `https://`, so a plain-HTTP OpenSearch node (e.g. `http://192.168.2.10:9200`) was unreachable — agent reads worked (Manager API is TLS) but alert/vuln reads via the indexer failed. Separately, `WAZUH_INDEXER_VERIFY_SSL` was read in config but never applied (the indexer silently reused the manager's `verify_ssl`).

- Indexer scheme now derives from an explicit `http://`/`https://` prefix on the host, or a new `WAZUH_INDEXER_SSL` flag; `base_url` no longer hardcodes the scheme.
- `WAZUH_INDEXER_SSL` is inferred from the host scheme when unset (defaults to HTTPS).
- `WAZUH_INDEXER_VERIFY_SSL` is now wired through to the indexer client.
- Documented both vars in `.env.example`.

## #73 — `get_wazuh_alerts` rejected relative time like `now-24h`
`timestamp_start`/`timestamp_end` flow straight into an OpenSearch `range` query, which evaluates date math natively — but `validate_timestamp` rejected anything that wasn't ISO 8601, so LLM clients sending `now-24h` got a hard error.

- `validate_timestamp` now accepts OpenSearch date math (`now`, `now-24h`, `now-7d/d`, ...) in addition to ISO 8601, normalizing the leading `now` keyword.
- Updated the `timestamp_start`/`timestamp_end` tool schema descriptions.

## Testing
Added/ran targeted checks: 7 accepted + 5 rejected timestamp cases (incl. injection strings); indexer `base_url` across prefix/flag/default combinations; config scheme inference (prefix vs explicit override); and an end-to-end `WazuhClient` build producing an `http://` indexer with verify-SSL wired through.

Closes #78
Closes #73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for HTTP connections to Wazuh Indexer (previously HTTPS-only).
  * Enabled configurable TLS certificate verification for both production and development environments.
  * Added support for relative date-math expressions (e.g., `now-24h`, `now-7d`) in timestamp queries alongside ISO-8601 format.

* **Documentation**
  * Enhanced configuration guidance for indexer SSL/TLS settings.
  * Updated timestamp parameter documentation to reflect supported formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->