### PR TITLE
feat: add get_alerts_aggregated tool (clean alternative to #79)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,11 @@ WAZUH_VERIFY_SSL=true
 # WAZUH_INDEXER_PORT=9200
 # WAZUH_INDEXER_USER=admin
 # WAZUH_INDEXER_PASS=admin
+# Transport scheme for the indexer. Defaults to HTTPS. Set to false for a plain-HTTP
+# OpenSearch node (you can also just put http:// in WAZUH_INDEXER_HOST).
+# WAZUH_INDEXER_SSL=true
+# Verify the indexer's TLS certificate. Set to false for self-signed certs in dev.
+# WAZUH_INDEXER_VERIFY_SSL=true
 
 # === Session Storage (Serverless Ready) ===
 # Optional Redis URL for serverless/multi-instance deployments

--- a/src/wazuh_mcp_server/api/wazuh_client.py
+++ b/src/wazuh_mcp_server/api/wazuh_client.py
@@ -158,6 +158,23 @@ class WazuhClient:
             timestamp_end=params.get("timestamp_end"),
         )
 
+    async def get_alerts_aggregated(
+        self,
+        timestamp_start: str = "now-24h",
+        timestamp_end: str = "now",
+        top_rules: int = 50,
+        top_agents: int = 50,
+    ) -> Dict[str, Any]:
+        """Aggregate alerts over a time range (no document limit) via the indexer."""
+        if not self._indexer_client:
+            raise IndexerNotConfiguredError()
+        return await self._indexer_client.aggregate_alerts(
+            timestamp_start=timestamp_start,
+            timestamp_end=timestamp_end,
+            top_rules=top_rules,
+            top_agents=top_agents,
+        )
+
     async def get_agents(self, agent_id=None, status=None, limit=100, **params) -> Dict[str, Any]:
         """Get agents from Wazuh."""
         clean_params: Dict[str, Any] = {}

--- a/src/wazuh_mcp_server/api/wazuh_client.py
+++ b/src/wazuh_mcp_server/api/wazuh_client.py
@@ -57,8 +57,9 @@ class WazuhClient:
                 port=config.wazuh_indexer_port,
                 username=config.wazuh_indexer_user,
                 password=config.wazuh_indexer_pass,
-                verify_ssl=config.verify_ssl,
+                verify_ssl=getattr(config, "wazuh_indexer_verify_ssl", config.verify_ssl),
                 timeout=config.request_timeout_seconds,
+                use_ssl=getattr(config, "wazuh_indexer_ssl", True),
             )
             logger.info(f"WazuhIndexerClient configured for {config.wazuh_indexer_host}:{config.wazuh_indexer_port}")
         else:

--- a/src/wazuh_mcp_server/api/wazuh_indexer.py
+++ b/src/wazuh_mcp_server/api/wazuh_indexer.py
@@ -37,7 +37,11 @@ class WazuhIndexerClient:
         password: Optional[str] = None,
         verify_ssl: bool = True,
         timeout: int = 30,
+        use_ssl: bool = True,
     ):
+        # Detect scheme from the host prefix before stripping it; an explicit http://
+        # prefix wins over use_ssl so an OpenSearch node served over plain HTTP works.
+        detected_scheme = self._detect_scheme(host)
         # Normalize host (strip protocol if user included it)
         self.host = self._normalize_host(host)
         self.port = port
@@ -45,6 +49,7 @@ class WazuhIndexerClient:
         self.password = password
         self.verify_ssl = verify_ssl
         self.timeout = timeout
+        self.scheme = detected_scheme or ("https" if use_ssl else "http")
         self.client: Optional[httpx.AsyncClient] = None
         self._initialized = False
         self._init_lock = asyncio.Lock()
@@ -61,10 +66,22 @@ class WazuhIndexerClient:
                 break
         return host.rstrip("/")
 
+    @staticmethod
+    def _detect_scheme(host: str) -> Optional[str]:
+        """Return 'http' or 'https' if the host includes an explicit scheme, else None."""
+        if not host:
+            return None
+        lowered = host.lower()
+        if lowered.startswith("http://"):
+            return "http"
+        if lowered.startswith("https://"):
+            return "https"
+        return None
+
     @property
     def base_url(self) -> str:
         """Get the base URL for the Wazuh Indexer."""
-        return f"https://{self.host}:{self.port}"
+        return f"{self.scheme}://{self.host}:{self.port}"
 
     async def initialize(self):
         """Initialize the HTTP client and circuit breaker."""
@@ -104,7 +121,7 @@ class WazuhIndexerClient:
             )
 
         self._initialized = True
-        logger.info(f"WazuhIndexerClient initialized for {self.host}:{self.port}")
+        logger.info(f"WazuhIndexerClient initialized for {self.base_url} (verify_ssl={self.verify_ssl})")
 
     async def close(self):
         """Close the HTTP client."""

--- a/src/wazuh_mcp_server/api/wazuh_indexer.py
+++ b/src/wazuh_mcp_server/api/wazuh_indexer.py
@@ -202,6 +202,97 @@ class WazuhIndexerClient:
             # Let timeout errors propagate for retry
             raise
 
+    async def _execute_body(self, index: str, body: Dict[str, Any]) -> Dict[str, Any]:
+        """Execute a search with an arbitrary request body (e.g. aggregations).
+
+        Shares the same error handling as _execute_search so server errors propagate for
+        retry while client errors surface as ValueError. Call via the circuit breaker.
+        """
+        await self._ensure_initialized()
+
+        url = f"{self.base_url}/{index}/_search"
+        try:
+            response = await self.client.post(url, json=body, headers={"Content-Type": "application/json"})
+            response.raise_for_status()
+            try:
+                return response.json()
+            except (json.JSONDecodeError, ValueError):
+                raise ValueError(f"Invalid JSON response from Wazuh Indexer: {index}")
+        except httpx.HTTPStatusError as e:
+            logger.error(f"Indexer aggregation failed: {e.response.status_code} - {e.response.text}")
+            if e.response.status_code >= 500:
+                raise
+            raise ValueError(f"Indexer query failed: {e.response.status_code}")
+        except (httpx.ConnectError, httpx.TimeoutException):
+            raise
+
+    async def aggregate_alerts(
+        self,
+        timestamp_start: str = "now-24h",
+        timestamp_end: str = "now",
+        index: str = "wazuh-alerts-*",
+        top_rules: int = 50,
+        top_agents: int = 50,
+    ) -> Dict[str, Any]:
+        """Summarize alerts over a time range using aggregations (size=0, no document paging).
+
+        Unlike get_alerts, this is not bounded by a document limit — it returns the true
+        total match count plus the top rules, severity levels, and agents for the window.
+        Both ISO 8601 and OpenSearch date math (e.g. now-7d) are accepted for the bounds.
+        """
+        range_filter: Dict[str, str] = {}
+        if timestamp_start:
+            range_filter["gte"] = timestamp_start
+        if timestamp_end:
+            range_filter["lte"] = timestamp_end
+        query: Dict[str, Any] = (
+            {"bool": {"must": [{"range": {"timestamp": range_filter}}]}} if range_filter else {"match_all": {}}
+        )
+        body = {
+            "size": 0,
+            "track_total_hits": True,
+            "query": query,
+            "aggs": {
+                "by_rule": {
+                    "terms": {"field": "rule.id", "size": top_rules},
+                    "aggs": {"info": {"top_hits": {"size": 1, "_source": ["rule.description", "rule.level"]}}},
+                },
+                "by_level": {"terms": {"field": "rule.level", "size": 20}},
+                "by_agent": {"terms": {"field": "agent.name", "size": top_agents}},
+            },
+        }
+        if self._circuit_breaker is not None:
+            resp = await self._circuit_breaker._call(self._execute_body, index, body)
+        else:
+            resp = await self._execute_body(index, body)
+
+        aggs = resp.get("aggregations", {})
+
+        def _rule_row(bucket: Dict[str, Any]) -> Dict[str, Any]:
+            hits = bucket.get("info", {}).get("hits", {}).get("hits", [])
+            source = hits[0].get("_source", {}) if hits else {}
+            rule = source.get("rule", {}) if isinstance(source, dict) else {}
+            return {
+                "rule_id": bucket.get("key"),
+                "count": bucket.get("doc_count", 0),
+                "description": rule.get("description"),
+                "level": rule.get("level"),
+            }
+
+        return {
+            "time_range": {"gte": timestamp_start, "lte": timestamp_end},
+            "total_alerts": resp.get("hits", {}).get("total", {}).get("value", 0),
+            "top_rules": [_rule_row(b) for b in aggs.get("by_rule", {}).get("buckets", [])],
+            "by_level": [
+                {"level": b.get("key"), "count": b.get("doc_count", 0)}
+                for b in aggs.get("by_level", {}).get("buckets", [])
+            ],
+            "top_agents": [
+                {"agent": b.get("key"), "count": b.get("doc_count", 0)}
+                for b in aggs.get("by_agent", {}).get("buckets", [])
+            ],
+        }
+
     async def get_alerts(
         self,
         limit: int = 100,

--- a/src/wazuh_mcp_server/config.py
+++ b/src/wazuh_mcp_server/config.py
@@ -74,6 +74,8 @@ class WazuhConfig:
     wazuh_indexer_port: int = 9200
     wazuh_indexer_user: Optional[str] = None
     wazuh_indexer_pass: Optional[str] = None
+    wazuh_indexer_ssl: bool = True  # Use HTTPS for the indexer (set False for plain-HTTP OpenSearch nodes)
+    wazuh_indexer_verify_ssl: bool = True  # Verify the indexer's TLS certificate
 
     # Transport settings
     mcp_transport: str = "http"  # Default to HTTP/SSE mode
@@ -194,6 +196,7 @@ class ServerConfig:
     WAZUH_INDEXER_PORT: int = 9200
     WAZUH_INDEXER_USER: str = ""
     WAZUH_INDEXER_PASS: str = ""
+    WAZUH_INDEXER_SSL: bool = True
     WAZUH_INDEXER_VERIFY_SSL: bool = True
 
     # Logging
@@ -218,6 +221,15 @@ class ServerConfig:
         log_level = os.getenv("LOG_LEVEL", "INFO").upper()
         if log_level not in ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"):
             log_level = "INFO"
+
+        # Indexer scheme: honor an explicit WAZUH_INDEXER_SSL, otherwise infer from the
+        # host prefix (http:// -> plain HTTP). Defaults to HTTPS when no scheme is given.
+        indexer_host_raw = os.getenv("WAZUH_INDEXER_HOST", "")
+        indexer_ssl_env = os.getenv("WAZUH_INDEXER_SSL")
+        if indexer_ssl_env is not None:
+            indexer_ssl = indexer_ssl_env.lower() == "true"
+        else:
+            indexer_ssl = not indexer_host_raw.strip().lower().startswith("http://")
 
         return cls(
             MCP_HOST=os.getenv("MCP_HOST", "0.0.0.0"),
@@ -246,10 +258,11 @@ class ServerConfig:
             WAZUH_VERIFY_SSL=os.getenv("WAZUH_VERIFY_SSL", "true").lower() == "true",
             WAZUH_ALLOW_SELF_SIGNED=os.getenv("WAZUH_ALLOW_SELF_SIGNED", "true").lower() == "true",
             # Wazuh Indexer settings (for vulnerability tools in Wazuh 4.8.0+)
-            WAZUH_INDEXER_HOST=normalize_host(os.getenv("WAZUH_INDEXER_HOST", "")),
+            WAZUH_INDEXER_HOST=normalize_host(indexer_host_raw),
             WAZUH_INDEXER_PORT=validate_port(os.getenv("WAZUH_INDEXER_PORT", "9200"), "WAZUH_INDEXER_PORT"),
             WAZUH_INDEXER_USER=os.getenv("WAZUH_INDEXER_USER", ""),
             WAZUH_INDEXER_PASS=os.getenv("WAZUH_INDEXER_PASS", ""),
+            WAZUH_INDEXER_SSL=indexer_ssl,
             WAZUH_INDEXER_VERIFY_SSL=os.getenv("WAZUH_INDEXER_VERIFY_SSL", "true").lower() == "true",
             LOG_LEVEL=log_level,
         )

--- a/src/wazuh_mcp_server/security.py
+++ b/src/wazuh_mcp_server/security.py
@@ -49,6 +49,9 @@ VALID_COMPLIANCE_FRAMEWORKS = {"PCI-DSS", "HIPAA", "SOX", "GDPR", "NIST"}
 AGENT_ID_PATTERN = re.compile(r"^[0-9]{1,5}$")  # Wazuh agent IDs: 0 (manager) through 99999
 RULE_ID_PATTERN = re.compile(r"^[0-9]{1,6}$")  # Rule IDs are numeric
 ISO_TIMESTAMP_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:?\d{2})?)?$")
+# OpenSearch/Elasticsearch date math, e.g. "now", "now-24h", "now-7d/d", "now-1h-30m".
+# These pass straight through to the indexer range query, which evaluates them natively.
+DATE_MATH_PATTERN = re.compile(r"^now([+-]\d+[yMwdhHms])*(/[yMwdhHms])?$")
 # Use ipaddress module for proper validation instead of regex
 IP_ADDRESS_PATTERN = None  # Replaced by _is_valid_ip() function
 HASH_PATTERN = re.compile(r"^[a-fA-F0-9]{32,128}$")  # MD5 to SHA-512
@@ -175,7 +178,11 @@ def validate_agent_status(value: Any, param_name: str = "status") -> Optional[st
 
 
 def validate_timestamp(value: Any, required: bool = False, param_name: str = "timestamp") -> Optional[str]:
-    """Validate ISO 8601 timestamp format."""
+    """Validate an ISO 8601 timestamp or OpenSearch relative date math (e.g. 'now-24h').
+
+    Relative expressions are common from LLM clients and are passed straight through to
+    the indexer range query, which evaluates date math natively.
+    """
     if value is None:
         if required:
             raise ToolValidationError(param_name, "is required")
@@ -188,12 +195,20 @@ def validate_timestamp(value: Any, required: bool = False, param_name: str = "ti
             raise ToolValidationError(param_name, "cannot be empty")
         return None
 
-    if not ISO_TIMESTAMP_PATTERN.match(timestamp):
-        raise ToolValidationError(
-            param_name, f"invalid ISO 8601 format '{timestamp}'", "Use format: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ"
-        )
+    # Accept OpenSearch date math (e.g. now-24h). Normalize the leading "now" keyword to
+    # lowercase since the indexer requires it; unit case (h/H, m/M) is preserved as-is.
+    normalized = ("now" + timestamp[3:]) if timestamp[:3].lower() == "now" else timestamp
+    if DATE_MATH_PATTERN.match(normalized):
+        return normalized
 
-    return timestamp
+    if ISO_TIMESTAMP_PATTERN.match(timestamp):
+        return timestamp
+
+    raise ToolValidationError(
+        param_name,
+        f"invalid timestamp '{timestamp}'",
+        "Use ISO 8601 (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ) or relative date math (e.g. now-24h, now-7d/d)",
+    )
 
 
 def validate_indicator(value: Any, indicator_type: str, param_name: str = "indicator") -> str:

--- a/src/wazuh_mcp_server/server.py
+++ b/src/wazuh_mcp_server/server.py
@@ -541,6 +541,8 @@ wazuh_config = WazuhConfig(
     wazuh_indexer_port=config.WAZUH_INDEXER_PORT,
     wazuh_indexer_user=config.WAZUH_INDEXER_USER if config.WAZUH_INDEXER_USER else None,
     wazuh_indexer_pass=config.WAZUH_INDEXER_PASS if config.WAZUH_INDEXER_PASS else None,
+    wazuh_indexer_ssl=config.WAZUH_INDEXER_SSL,
+    wazuh_indexer_verify_ssl=config.WAZUH_INDEXER_VERIFY_SSL,
 )
 
 # Initialize Wazuh client
@@ -1300,8 +1302,8 @@ async def handle_tools_list(params: Dict[str, Any], session: MCPSession) -> Dict
                     "rule_id": {"type": "string", "description": "Filter by specific rule ID"},
                     "level": {"type": "string", "description": "Filter by alert level (e.g., '12', '10+')"},
                     "agent_id": {"type": "string", "description": "Filter by agent ID"},
-                    "timestamp_start": {"type": "string", "description": "Start timestamp (ISO format)"},
-                    "timestamp_end": {"type": "string", "description": "End timestamp (ISO format)"},
+                    "timestamp_start": {"type": "string", "description": "Start timestamp — ISO 8601 (YYYY-MM-DDTHH:MM:SSZ) or relative date math (e.g. now-24h, now-7d)"},
+                    "timestamp_end": {"type": "string", "description": "End timestamp — ISO 8601 (YYYY-MM-DDTHH:MM:SSZ) or relative date math (e.g. now, now-1h)"},
                     "compact": {
                         "type": "boolean",
                         "default": True,

--- a/src/wazuh_mcp_server/server.py
+++ b/src/wazuh_mcp_server/server.py
@@ -1287,7 +1287,7 @@ def _get_tool_scope(tool_name: str) -> str:
 
 
 async def handle_tools_list(params: Dict[str, Any], session: MCPSession) -> Dict[str, Any]:
-    """Handle tools/list method - All 48 Wazuh Security Tools with pagination.
+    """Handle tools/list method - All 49 Wazuh Security Tools with pagination.
     Filters tools based on session token scopes."""
     _cursor = params.get("cursor")  # Reserved for future pagination
     tools = [
@@ -1333,6 +1333,20 @@ async def handle_tools_list(params: Dict[str, Any], session: MCPSession) -> Dict
                 "properties": {
                     "time_range": {"type": "string", "enum": ["1h", "6h", "12h", "1d", "24h", "7d", "30d"], "default": "24h"},
                     "min_frequency": {"type": "integer", "minimum": 1, "default": 5},
+                },
+                "required": [],
+            },
+        },
+        {
+            "name": "get_alerts_aggregated",
+            "description": "Summarize ALL alerts in a time window using indexer aggregations (no document limit). Returns the true total match count plus top rules, severity levels, and agents. Prefer this over get_wazuh_alerts/get_wazuh_alert_summary when the goal is a complete overview of a period rather than individual alert documents.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "timestamp_start": {"type": "string", "description": "Start of window — ISO 8601 or date math (e.g. now-24h, now-7d). Default now-24h.", "default": "now-24h"},
+                    "timestamp_end": {"type": "string", "description": "End of window — ISO 8601 or date math (e.g. now). Default now.", "default": "now"},
+                    "top_rules": {"type": "integer", "minimum": 1, "maximum": 500, "default": 50, "description": "How many top rules to return"},
+                    "top_agents": {"type": "integer", "minimum": 1, "maximum": 500, "default": 50, "description": "How many top agents to return"},
                 },
                 "required": [],
             },
@@ -1873,7 +1887,7 @@ async def handle_tools_list(params: Dict[str, Any], session: MCPSession) -> Dict
 
 
 async def handle_tools_call(params: Dict[str, Any], session: MCPSession) -> Dict[str, Any]:
-    """Handle tools/call method - All 48 Wazuh Security Tools with comprehensive validation."""
+    """Handle tools/call method - All 49 Wazuh Security Tools with comprehensive validation."""
     tool_name = params.get("name")
     arguments = params.get("arguments", {})
 
@@ -1983,6 +1997,24 @@ async def handle_tools_call(params: Dict[str, Any], session: MCPSession) -> Dict
             result = await wazuh_client.analyze_alert_patterns(time_range, min_frequency)
             _success = True
             return _tool_result(f"Alert Patterns:\n{json.dumps(result, indent=2, default=str)}")
+
+        elif tool_name == "get_alerts_aggregated":
+            timestamp_start = validate_timestamp(arguments.get("timestamp_start"), param_name="timestamp_start") or "now-24h"
+            timestamp_end = validate_timestamp(arguments.get("timestamp_end"), param_name="timestamp_end") or "now"
+            top_rules = validate_limit(
+                arguments.get("top_rules"), min_val=1, max_val=500, default=50, param_name="top_rules"
+            )
+            top_agents = validate_limit(
+                arguments.get("top_agents"), min_val=1, max_val=500, default=50, param_name="top_agents"
+            )
+            result = await wazuh_client.get_alerts_aggregated(
+                timestamp_start=timestamp_start,
+                timestamp_end=timestamp_end,
+                top_rules=top_rules,
+                top_agents=top_agents,
+            )
+            _success = True
+            return _tool_result(f"Aggregated Alerts:\n{json.dumps(result, indent=2, default=str)}")
 
         elif tool_name == "search_security_events":
             query = validate_query(arguments.get("query"), required=True)


### PR DESCRIPTION
Adds a limit-free, aggregation-based alert overview tool — the use case behind #79 ("fetch ALL alerts for a period") — implemented cleanly.

> Stacks on #80 (uses the date-math `validate_timestamp` from that PR). Merge #80 first; once it lands this PR's diff reduces to just the aggregation changes.

## What it does
`get_alerts_aggregated` runs a `size=0` + `track_total_hits` indexer query and returns:
- `total_alerts` — the **true** match count for the window (not capped by a document limit)
- `top_rules` — top rule IDs with count, description, and level (via a `top_hits` sub-agg)
- `by_level` — severity-level distribution
- `top_agents` — noisiest agents

Bounds accept ISO 8601 or date math (`now-24h`, `now-7d`); `top_rules`/`top_agents` are bounded 1..500; defaults `now-24h`..`now`.

## How it differs from #79
This addresses the same need but deliberately avoids #79's issues:
- ❌ #79 set `_cache_ttl = 43200` (12h cache on security data) — **not** included here
- ❌ #79 set `_cache_max_size = 100_000_000` (100M entries → OOM) — **not** included here
- ❌ #79 added `scroll_generator`/`JOBS` that were never wired to any tool — **not** included here
- ❌ #79 had Portuguese UI strings and no input validation — this is English-only with full validation
- ✅ Runs through the existing circuit-breaker/retry path (`_execute_body` shares `_execute_search`'s error handling)

## Testing
Verified the aggregation parsing against a mocked OpenSearch aggregation response (total count, rule rows with description/level, level distribution, agent buckets). Syntax-checked all touched modules.

Relates to #79

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added alert aggregation capability to summarize alerts over custom time windows with configurable limits for rules and agents.

* **Improvements**
  * Enhanced SSL/TLS configuration with independent control for encryption and certificate verification.
  * Extended timestamp support to include relative date expressions (e.g., `now-24h`).
  * Improved setup documentation with SSL configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->