### PR TITLE
feat: add optional you.com search integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **Talk to your SIEM.** Query alerts, hunt threats, check vulnerabilities, and trigger active responses across your entire Wazuh deployment — through natural conversation with any AI assistant.
 
-> **v4.2.1** | 54 security tools | Wazuh 4.8.0–4.14.4 | [Changelog](CHANGELOG.md)
+> **v4.2.1** | 55 security tools | Wazuh 4.8.0–4.14.4 | [Changelog](CHANGELOG.md)
 
 ---
 
@@ -75,7 +75,7 @@ Open WebUI v0.6.31+ connects to our `/mcp` endpoint natively. Add it as an MCP t
 
 ---
 
-## 54 Security Tools
+## 55 Security Tools
 
 Every tool is validated, rate-limited, scope-checked, and audit-logged.
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Every tool is validated, rate-limited, scope-checked, and audit-logged.
 | **Alerts** (5) | `get_wazuh_alerts` `get_wazuh_alert_summary` `get_alerts_aggregated` `analyze_alert_patterns` `search_security_events` | Query, filter, search, and aggregate alert data via the Indexer. Timestamps accept ISO 8601 or relative date math (`now-24h`); `get_alerts_aggregated` summarizes a whole period with no document limit |
 | **Agents** (6) | `get_wazuh_agents` `get_wazuh_running_agents` `check_agent_health` `get_agent_processes` `get_agent_ports` `get_agent_configuration` | Monitor agent status, running processes, open ports, and configs |
 | **Vulnerabilities** (3) | `get_wazuh_vulnerabilities` `get_wazuh_critical_vulnerabilities` `get_wazuh_vulnerability_summary` | Query CVEs by severity, agent, and package |
-| **Security Analysis** (5) | `analyze_security_threat` `check_ioc_reputation` `perform_risk_assessment` `get_top_security_threats` `generate_security_report` | Threat analysis, IOC lookup, risk scoring, security reports |
+| **Security Analysis** (6) | `analyze_security_threat` `check_ioc_reputation` `search_external_context` `perform_risk_assessment` `get_top_security_threats` `generate_security_report` | Threat analysis, IOC lookup, optional web context, risk scoring, security reports |
 | **Compliance** (6) | `run_compliance_check` `get_iso27001_dashboard` `get_iso27001_control_detail` `get_iso27001_gap_analysis` `get_iso27001_alerts` `get_sca_policy_checks` | Compliance scoring for PCI-DSS, HIPAA, SOX, GDPR, NIST, and ISO 27001:2022 (Annex A control mapping, gap analysis, SCA detail) |
 | **System** (10) | `get_wazuh_statistics` `get_wazuh_cluster_health` `get_wazuh_cluster_nodes` `get_wazuh_rules_summary` `search_wazuh_manager_logs` `get_wazuh_manager_error_logs` `get_wazuh_log_collector_stats` `get_wazuh_remoted_stats` `get_wazuh_weekly_stats` `validate_wazuh_connection` | Cluster health, rules, manager logs, stats, connectivity |
 | **Active Response** (9) | `wazuh_block_ip` `wazuh_isolate_host` `wazuh_kill_process` `wazuh_disable_user` `wazuh_quarantine_file` `wazuh_firewall_drop` `wazuh_host_deny` `wazuh_active_response` `wazuh_restart` | Block IPs, isolate hosts, kill processes, quarantine files |
@@ -194,6 +194,8 @@ python -c "import secrets; print('wazuh_' + secrets.token_urlsafe(32))"
 | `WAZUH_INDEXER_PASS` | — | Indexer password |
 | `WAZUH_INDEXER_SSL` | `true` | Use HTTPS for the Indexer (set `false` for a plain-HTTP OpenSearch node) |
 | `WAZUH_INDEXER_VERIFY_SSL` | `true` | Verify the Indexer's TLS certificate |
+| `YDC_API_KEY` | — | Optional You.com API key. Enables the `search_external_context` tool |
+| `YDC_BASE_URL` | `https://ydc-index.io` | Optional You.com Search API base URL |
 
 > Full reference: [Configuration Guide](docs/configuration.md)
 

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ python -c "import secrets; print('wazuh_' + secrets.token_urlsafe(32))"
 | `WAZUH_INDEXER_VERIFY_SSL` | `true` | Verify the Indexer's TLS certificate |
 | `YDC_API_KEY` | — | Optional You.com API key. Enables the `search_external_context` tool |
 | `YDC_BASE_URL` | `https://ydc-index.io` | Optional You.com Search API base URL |
+| `YDC_VERIFY_SSL` | `true` | Verify You.com TLS certificates independently of Wazuh |
 
 > Full reference: [Configuration Guide](docs/configuration.md)
 
@@ -218,7 +219,7 @@ python -c "import secrets; print('wazuh_' + secrets.token_urlsafe(32))"
 
 ```
 src/wazuh_mcp_server/
-├── server.py           # MCP protocol + 54 tool handlers
+├── server.py           # MCP protocol + 55 tool handlers
 ├── config.py           # Environment-based configuration
 ├── auth.py             # JWT + API key authentication
 ├── oauth.py            # OAuth 2.0 with Dynamic Client Registration

--- a/src/wazuh_mcp_server/api/wazuh_client.py
+++ b/src/wazuh_mcp_server/api/wazuh_client.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 import math
+import os
 import time
 from collections import OrderedDict, deque
 from datetime import datetime, timedelta, timezone
@@ -19,6 +20,8 @@ logger = logging.getLogger(__name__)
 
 # Time range to hours mapping for indexer-based queries
 _TIME_RANGE_HOURS = {"1h": 1, "6h": 6, "12h": 12, "1d": 24, "24h": 24, "7d": 168, "30d": 720}
+
+YDC_DEFAULT_BASE_URL = "https://ydc-index.io"
 
 # ISO 27001:2022 Annex A control map — links each control to Wazuh data sources
 # data_source: "sca" | "alerts" | "vulnerabilities" | "agents" | "stats" | "none"
@@ -156,6 +159,8 @@ class WazuhClient:
         self._cache: OrderedDict[str, Tuple[float, Dict[str, Any]]] = OrderedDict()
         self._cache_ttl = 300  # 5 minutes for static data
         self._cache_max_size = 100
+        self._youcom_api_key = os.getenv("YDC_API_KEY", "").strip() or None
+        self._youcom_base_url = os.getenv("YDC_BASE_URL", YDC_DEFAULT_BASE_URL).rstrip("/")
 
         # Circuit breaker for API resilience — only trip on connection/server errors,
         # not on user-input errors (ValueError) which shouldn't degrade the circuit
@@ -911,6 +916,39 @@ class WazuhClient:
                 "risk": risk,
             }
         }
+
+    async def search_external_context(self, query: str, count: int = 5) -> Dict[str, Any]:
+        """Search the web with You.com for additional security context."""
+        if not self._youcom_api_key:
+            return {
+                "data": {
+                    "query": query,
+                    "enabled": False,
+                    "results": [],
+                    "message": "Set YDC_API_KEY to enable optional You.com web search context.",
+                }
+            }
+
+        params = {"query": query, "count": max(1, min(count, 10)), "safesearch": "moderate", "livecrawl": "web"}
+        url = f"{self._youcom_base_url}/v1/search"
+        async with httpx.AsyncClient(timeout=self.config.request_timeout_seconds, verify=self.config.verify_ssl) as client:
+            response = await client.get(url, params=params, headers={"X-API-Key": self._youcom_api_key})
+        if response.status_code >= 400:
+            raise ValueError(f"You.com Search API error {response.status_code}: {response.text}")
+
+        payload = response.json()
+        web_results = payload.get("results", {}).get("web", [])[:count]
+        results = []
+        for item in web_results:
+            results.append(
+                {
+                    "title": item.get("title"),
+                    "url": item.get("url"),
+                    "description": item.get("description"),
+                    "snippets": item.get("snippets", []),
+                }
+            )
+        return {"data": {"query": query, "enabled": True, "results": results, "search_uuid": payload.get("metadata", {}).get("search_uuid")}}
 
     async def perform_risk_assessment(self, agent_id: str = None) -> Dict[str, Any]:
         """Perform risk assessment from agent status, vulnerability data, and alert severity."""

--- a/src/wazuh_mcp_server/api/wazuh_client.py
+++ b/src/wazuh_mcp_server/api/wazuh_client.py
@@ -161,6 +161,7 @@ class WazuhClient:
         self._cache_max_size = 100
         self._youcom_api_key = os.getenv("YDC_API_KEY", "").strip() or None
         self._youcom_base_url = os.getenv("YDC_BASE_URL", YDC_DEFAULT_BASE_URL).rstrip("/")
+        self._youcom_verify_ssl = os.getenv("YDC_VERIFY_SSL", "true").strip().lower() == "true"
 
         # Circuit breaker for API resilience — only trip on connection/server errors,
         # not on user-input errors (ValueError) which shouldn't degrade the circuit
@@ -930,14 +931,7 @@ class WazuhClient:
             }
 
         clamped_count = max(1, min(count, 10))
-        params = {"query": query, "count": clamped_count, "safesearch": "moderate", "livecrawl": "web"}
-        url = f"{self._youcom_base_url}/v1/search"
-        async with httpx.AsyncClient(timeout=self.config.request_timeout_seconds, verify=True) as client:
-            response = await client.get(url, params=params, headers={"X-API-Key": self._youcom_api_key})
-        if response.status_code >= 400:
-            raise ValueError(f"You.com Search API error {response.status_code}: {response.text}")
-
-        payload = response.json()
+        payload = await self._search_youcom(query, clamped_count)
         web_results = payload.get("results", {}).get("web", [])[:clamped_count]
         results = []
         for item in web_results:
@@ -950,6 +944,21 @@ class WazuhClient:
                 }
             )
         return {"data": {"query": query, "enabled": True, "results": results, "search_uuid": payload.get("metadata", {}).get("search_uuid")}}
+
+    async def _search_youcom(self, query: str, count: int) -> Dict[str, Any]:
+        """Search You.com with the same resilience wrapper used for Wazuh requests."""
+        async with self._rate_limiter:
+            await self._rate_limit_check()
+            return await self._circuit_breaker._call(self._execute_youcom_search, query, count)
+
+    async def _execute_youcom_search(self, query: str, count: int) -> Dict[str, Any]:
+        params = {"query": query, "count": count, "safesearch": "moderate", "livecrawl": "web"}
+        url = f"{self._youcom_base_url}/v1/search"
+        async with httpx.AsyncClient(timeout=self.config.request_timeout_seconds, verify=self._youcom_verify_ssl) as client:
+            response = await client.get(url, params=params, headers={"X-API-Key": self._youcom_api_key})
+        if response.status_code >= 400:
+            raise ValueError(f"You.com Search API error {response.status_code}: {response.text}")
+        return response.json()
 
     async def perform_risk_assessment(self, agent_id: str = None) -> Dict[str, Any]:
         """Perform risk assessment from agent status, vulnerability data, and alert severity."""

--- a/src/wazuh_mcp_server/api/wazuh_client.py
+++ b/src/wazuh_mcp_server/api/wazuh_client.py
@@ -929,15 +929,16 @@ class WazuhClient:
                 }
             }
 
-        params = {"query": query, "count": max(1, min(count, 10)), "safesearch": "moderate", "livecrawl": "web"}
+        clamped_count = max(1, min(count, 10))
+        params = {"query": query, "count": clamped_count, "safesearch": "moderate", "livecrawl": "web"}
         url = f"{self._youcom_base_url}/v1/search"
-        async with httpx.AsyncClient(timeout=self.config.request_timeout_seconds, verify=self.config.verify_ssl) as client:
+        async with httpx.AsyncClient(timeout=self.config.request_timeout_seconds, verify=True) as client:
             response = await client.get(url, params=params, headers={"X-API-Key": self._youcom_api_key})
         if response.status_code >= 400:
             raise ValueError(f"You.com Search API error {response.status_code}: {response.text}")
 
         payload = response.json()
-        web_results = payload.get("results", {}).get("web", [])[:count]
+        web_results = payload.get("results", {}).get("web", [])[:clamped_count]
         results = []
         for item in web_results:
             results.append(

--- a/src/wazuh_mcp_server/api/wazuh_client.py
+++ b/src/wazuh_mcp_server/api/wazuh_client.py
@@ -171,6 +171,15 @@ class WazuhClient:
             expected_exception=(ConnectionError, httpx.ConnectError, httpx.TimeoutException, httpx.HTTPStatusError),
         )
         self._circuit_breaker = CircuitBreaker(circuit_config)
+        # Separate breaker for the optional You.com integration — an external search
+        # outage must never open the circuit that gates Wazuh API calls
+        self._youcom_circuit_breaker = CircuitBreaker(
+            CircuitBreakerConfig(
+                failure_threshold=5,
+                recovery_timeout=60,
+                expected_exception=(ConnectionError, httpx.ConnectError, httpx.TimeoutException, httpx.HTTPStatusError),
+            )
+        )
 
         # Initialize Wazuh Indexer client if configured (required for Wazuh 4.8.0+)
         self._indexer_client: Optional[WazuhIndexerClient] = None
@@ -946,10 +955,9 @@ class WazuhClient:
         return {"data": {"query": query, "enabled": True, "results": results, "search_uuid": payload.get("metadata", {}).get("search_uuid")}}
 
     async def _search_youcom(self, query: str, count: int) -> Dict[str, Any]:
-        """Search You.com with the same resilience wrapper used for Wazuh requests."""
+        """Search You.com behind its own circuit breaker, isolated from Wazuh API resilience state."""
         async with self._rate_limiter:
-            await self._rate_limit_check()
-            return await self._circuit_breaker._call(self._execute_youcom_search, query, count)
+            return await self._youcom_circuit_breaker._call(self._execute_youcom_search, query, count)
 
     async def _execute_youcom_search(self, query: str, count: int) -> Dict[str, Any]:
         params = {"query": query, "count": count, "safesearch": "moderate", "livecrawl": "web"}
@@ -957,7 +965,7 @@ class WazuhClient:
         async with httpx.AsyncClient(timeout=self.config.request_timeout_seconds, verify=self._youcom_verify_ssl) as client:
             response = await client.get(url, params=params, headers={"X-API-Key": self._youcom_api_key})
         if response.status_code >= 400:
-            raise ValueError(f"You.com Search API error {response.status_code}: {response.text}")
+            raise ValueError(f"You.com Search API error {response.status_code}: {response.text[:200]}")
         return response.json()
 
     async def perform_risk_assessment(self, agent_id: str = None) -> Dict[str, Any]:

--- a/src/wazuh_mcp_server/server.py
+++ b/src/wazuh_mcp_server/server.py
@@ -1604,6 +1604,18 @@ async def handle_tools_list(params: Dict[str, Any], session: MCPSession) -> Dict
             },
         },
         {
+            "name": "search_external_context",
+            "description": "Search the web for additional context around an indicator or security topic (opt-in via YDC_API_KEY)",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string", "description": "Security topic or indicator to search for"},
+                    "count": {"type": "integer", "minimum": 1, "maximum": 10, "default": 5},
+                },
+                "required": ["query"],
+            },
+        },
+        {
             "name": "perform_risk_assessment",
             "description": "Perform comprehensive risk assessment for agents or the entire environment",
             "inputSchema": {
@@ -2339,6 +2351,14 @@ async def handle_tools_call(params: Dict[str, Any], session: MCPSession) -> Dict
             result = await wazuh_client.check_ioc_reputation(indicator, indicator_type)
             _success = True
             return _tool_result(f"IoC Reputation:\n{json.dumps(result, indent=2, default=str)}")
+
+        elif tool_name == "search_external_context":
+            query = validate_input(arguments.get("query"), "query", required=True)
+            count = validate_limit(arguments.get("count"), min_val=1, max_val=10, default=5, param_name="count")
+
+            result = await wazuh_client.search_external_context(query, count)
+            _success = True
+            return _tool_result(f"External Context:\n{json.dumps(result, indent=2, default=str)}")
 
         elif tool_name == "perform_risk_assessment":
             agent_id = validate_agent_id(arguments.get("agent_id"))

--- a/src/wazuh_mcp_server/server.py
+++ b/src/wazuh_mcp_server/server.py
@@ -1375,7 +1375,7 @@ def _get_tool_scope(tool_name: str) -> str:
 
 
 async def handle_tools_list(params: Dict[str, Any], session: MCPSession) -> Dict[str, Any]:
-    """Handle tools/list method - All 54 Wazuh Security Tools with pagination.
+    """Handle tools/list method - All 55 Wazuh Security Tools with pagination.
     Filters tools based on session token scopes."""
     _cursor = params.get("cursor")  # Reserved for future pagination
     tools = [
@@ -2101,7 +2101,7 @@ async def handle_tools_list(params: Dict[str, Any], session: MCPSession) -> Dict
 
 
 async def handle_tools_call(params: Dict[str, Any], session: MCPSession) -> Dict[str, Any]:
-    """Handle tools/call method - All 54 Wazuh Security Tools with comprehensive validation."""
+    """Handle tools/call method - All 55 Wazuh Security Tools with comprehensive validation."""
     tool_name = params.get("name")
     arguments = params.get("arguments", {})
 
@@ -2353,7 +2353,7 @@ async def handle_tools_call(params: Dict[str, Any], session: MCPSession) -> Dict
             return _tool_result(f"IoC Reputation:\n{json.dumps(result, indent=2, default=str)}")
 
         elif tool_name == "search_external_context":
-            query = validate_input(arguments.get("query"), "query", required=True)
+            query = validate_query(arguments.get("query"), required=True)
             count = validate_limit(arguments.get("count"), min_val=1, max_val=10, default=5, param_name="count")
 
             result = await wazuh_client.search_external_context(query, count)

--- a/tests/integration/test_business_logic.py
+++ b/tests/integration/test_business_logic.py
@@ -194,6 +194,67 @@ class TestMCPResponseJsonRpc:
         assert resp.dict() == resp.model_dump()
 
 
+class TestYouComSearchIntegration:
+    @pytest.mark.asyncio
+    async def test_search_external_context_disabled_without_key(self, monkeypatch):
+        from wazuh_mcp_server.api.wazuh_client import WazuhClient
+        from wazuh_mcp_server.config import WazuhConfig
+
+        monkeypatch.delenv("YDC_API_KEY", raising=False)
+        client = WazuhClient(
+            WazuhConfig(wazuh_host="localhost", wazuh_user="test", wazuh_pass="test", verify_ssl=False)
+        )
+
+        result = await client.search_external_context("malware.io", 3)
+        assert result["data"]["enabled"] is False
+        assert result["data"]["results"] == []
+
+    @pytest.mark.asyncio
+    async def test_search_external_context_success(self, monkeypatch):
+        from wazuh_mcp_server.api import wazuh_client as client_module
+        from wazuh_mcp_server.api.wazuh_client import WazuhClient
+        from wazuh_mcp_server.config import WazuhConfig
+
+        monkeypatch.setenv("YDC_API_KEY", "test-key")
+        monkeypatch.setenv("YDC_BASE_URL", "https://ydc-index.io")
+
+        class DummyResponse:
+            status_code = 200
+            text = "ok"
+
+            def json(self):
+                return {
+                    "metadata": {"search_uuid": "abc-123"},
+                    "results": {"web": [{"title": "Result", "url": "https://example.com", "description": "desc", "snippets": ["snip"]}]},
+                }
+
+        class DummyClient:
+            def __init__(self, *args, **kwargs):
+                self.kwargs = kwargs
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def get(self, url, params=None, headers=None):
+                assert url.endswith("/v1/search")
+                assert headers == {"X-API-Key": "test-key"}
+                assert params["query"] == "malware.io"
+                return DummyResponse()
+
+        monkeypatch.setattr(client_module.httpx, "AsyncClient", DummyClient)
+
+        client = WazuhClient(
+            WazuhConfig(wazuh_host="localhost", wazuh_user="test", wazuh_pass="test", verify_ssl=False)
+        )
+        result = await client.search_external_context("malware.io", 3)
+        assert result["data"]["enabled"] is True
+        assert result["data"]["search_uuid"] == "abc-123"
+        assert result["data"]["results"][0]["title"] == "Result"
+
+
 class TestTimeRangeSync:
     """Tests for synchronized time range values (Fix #8)."""
 


### PR DESCRIPTION
This adds an optional You.com-backed search tool for security investigations where live web context helps.

What changed
- added `search_external_context` as an opt-in tool, enabled only when `YDC_API_KEY` is set
- wired the tool into the MCP server tool list and handler
- documented the new env vars in the README
- added focused tests for the enabled and disabled paths and response shaping

Setup
- set `YDC_API_KEY=<your key>`
- optional: set `YDC_BASE_URL=https://ydc-index.io`

Usage
```json
{ "query": "CVE-2026-xxxx exploitation", "count": 5 }
```

Validation
- `pytest -q tests/integration/test_business_logic.py` could not be run here because `pytest` is not installed in this workspace
- verified the change stays opt-in and does not affect default behavior when `YDC_API_KEY` is unset

Fallback / error handling
- if `YDC_API_KEY` is unset, the tool returns a clear disabled message and no results
- non-2xx You.com responses raise a clear error

Tracking issue
- https://github.com/youdotcom-oss/integration-tracking/issues/52

Happy to adjust the tool shape if you'd prefer this to plug into a different investigation flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `search_external_context` to retrieve external web context through optional You.com Search integration.
  * Added configuration options for the API key, base URL, and SSL verification.
  * Expanded the available security tool catalog to 55 tools.
* **Documentation**
  * Updated README tooling counts, architecture details, and configuration guidance.
* **Tests**
  * Added coverage for disabled searches and successful external search requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->