### PR TITLE
docs: full accuracy audit across README, guides, and API reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,14 +36,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`AUTH_SECRET_KEY` required in production**: with `ENVIRONMENT=production` and `AUTH_MODE != none`, the server refuses to start without it (prevents per-restart token invalidation and cross-instance auth failures).
 - **OAuth hardened**: mandatory S256 PKCE, single-use authorization codes, refresh-token rotation with replay detection, an effective revocation denylist, and DCR off by default with redirect-URI validation.
 - **Indexer queries** use `term` (not `match`) for exact keyword/IP filters; `hits.total` parsing tolerates both int and object forms; 401/403 returns a clear credentials message.
-- **Dependencies** trimmed (removed unused `fastmcp`, `passlib`, `aiofiles`) and pinned with upper bounds; tool count is now **54**.
+- **Dependencies** trimmed (removed unused `fastmcp`, `passlib`, `aiofiles`) and pinned with upper bounds; tool count is now **55** (including the optional `search_external_context`).
 
 ### Fixed
 - **ISO 27001 tools no longer query the removed Manager `/alerts` endpoint** (404 on Wazuh 4.8+): the dashboard, control detail, and alert-mapping paths now read alert evidence from the Indexer, with rule-group filtering, so alert-backed controls stop reporting false `no_evidence` gaps (#84).
 - **System metrics never collected**: `MetricsCollector` is now started/stopped in the app lifespan, so `/metrics` reports real CPU/memory (previously always `0`).
 - **Circuit breaker tripped on 429**: an upstream rate-limit no longer opens the breaker (5xx still does).
 - **`tools/list` `nextCursor: null`**: confirmed resolved — list responses omit the cursor field (#75).
-- Documentation corrected for accuracy: real env-var reference, 54-tool inventory, removed non-existent config keys, and the no-built-in-TLS (reverse-proxy) note.
+- Documentation corrected for accuracy: real env-var reference, 55-tool inventory, removed non-existent config keys, and the no-built-in-TLS (reverse-proxy) note.
 
 ## [4.2.1] - 2026-03-26
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,10 +42,9 @@ The implementation provides enterprise-grade integration between Claude Desktop 
 ## 🛠️ Development Setup
 
 ### Prerequisites
-- **Python 3.13+** recommended
+- **Python 3.11+** (the project baseline; newer versions work)
 - **Git** with GitHub access
-- **Docker 20.10+** with Compose v2.20+
-- **Node.js** (for pre-commit hooks)
+- **Docker** with Compose v2
 
 ### Quick Setup
 ```bash
@@ -57,8 +56,8 @@ cd Wazuh-MCP-Server
 python -m venv venv
 source venv/bin/activate  # Windows: venv\Scripts\activate
 
-# 3. Install development dependencies
-pip install -r requirements.txt
+# 3. Install the package with development dependencies (pytest, black, ruff)
+pip install -e ".[dev]"
 
 # 4. For Docker development (recommended)
 docker compose -f compose.dev.yml up -d --build
@@ -70,7 +69,7 @@ docker compose -f compose.dev.yml up -d --build
 cp .env.example .env
 
 # Edit with your Wazuh server details
-# See INSTALLATION.md for detailed configuration options
+# See docs/configuration.md for the full configuration reference
 ```
 
 ## 📂 Repository Structure
@@ -82,7 +81,8 @@ Wazuh-MCP-Server/
 │       ├── ci.yml             # Continuous Integration
 │       ├── release.yml        # Release automation
 │       ├── security.yml       # Security scanning
-│       └── branch-sync.yml    # Branch synchronization
+│       ├── docker-publish.yml # Container image build + scan + publish
+│       └── update-contributors.yml
 ├── src/wazuh_mcp_server/      # Main source code
 │   ├── __init__.py
 │   ├── __main__.py            # Entry point (python -m wazuh_mcp_server)
@@ -96,10 +96,9 @@ Wazuh-MCP-Server/
 │   ├── resilience.py          # Circuit breakers, retries, graceful shutdown
 │   ├── session_store.py       # Pluggable sessions (in-memory + Redis)
 │   └── api/                   # Wazuh Manager + Indexer clients
-├── tests/                     # Test suite
+├── tests/
+│   └── integration/           # Integration test suite
 ├── tools/                     # Development tools
-│   ├── branch-sync.py         # Branch synchronization
-│   └── version-manager.py     # Version management
 ├── Dockerfile                # Docker container configuration
 ├── compose.yml              # Docker Compose setup
 ├── compose.dev.yml          # Development Docker Compose
@@ -108,7 +107,7 @@ Wazuh-MCP-Server/
 ├── pyproject.toml          # Python project configuration
 ├── README.md               # Main documentation
 ├── CONTRIBUTING.md         # This file
-├── INSTALLATION.md         # Installation guide
+├── docs/                   # Guides and API reference
 └── .env.example           # Environment template
 ```
 
@@ -125,8 +124,8 @@ Wazuh-MCP-Server/
 - `deploy-production.sh` - Automated deployment script
 
 **Documentation**:
-- `README.md` - Main project documentation
-- `INSTALLATION.md` - Detailed installation guide
+- `README.md` - Main project documentation and quick start
+- `docs/configuration.md` - Full configuration reference
 - `MCP_COMPLIANCE_VERIFICATION.md` - MCP compliance details
 
 ## 🔄 Development Workflow
@@ -150,10 +149,10 @@ git commit -m "feat: add new security tool for vulnerability scanning"
 # Run tests
 pytest tests/ -v
 
-# Run linting
+# Run linting and formatting
 ruff check src/
 black src/
-mypy src/
+isort src/
 
 # Test the MCP remote server
 docker compose up -d --build
@@ -176,10 +175,7 @@ curl -H "Authorization: Bearer YOUR_TOKEN" \
 ### Test Structure
 ```
 tests/
-├── unit/                  # Unit tests
-├── integration/           # Integration tests
-├── fixtures/             # Test data
-└── conftest.py           # Pytest configuration
+└── integration/           # Integration tests (protocol, auth, tools, resilience)
 ```
 
 ### Running Tests
@@ -187,19 +183,16 @@ tests/
 # All tests
 pytest tests/ -v
 
-# Unit tests only
-pytest tests/unit/ -v
-
 # With coverage
 pytest tests/ --cov=src/wazuh_mcp_server --cov-report=html
 
 # Specific test file
-pytest tests/unit/test_wazuh_client.py -v
+pytest tests/integration/test_mcp_protocol.py -v
 ```
 
 ### Test Requirements
 - All new features must include tests
-- Maintain >90% code coverage
+- Do not decrease coverage — CI enforces a branch-coverage floor (`fail_under` in `pyproject.toml`)
 - Include both positive and negative test cases
 - Mock external dependencies (Wazuh API calls)
 
@@ -207,15 +200,14 @@ pytest tests/unit/test_wazuh_client.py -v
 
 ### Version Strategy
 - **Main Branch**: Semantic versioning `4.x.x`
-  - `4.0.0` - Current stable MCP remote server version
-  - `4.x.x` - Future releases with SSE transport
+  - `4.3.0` - Current stable release (see [CHANGELOG.md](CHANGELOG.md))
 
 ### Release Process
 1. **Automated Releases**: Triggered by version tags
    ```bash
    # Create and push version tag
-   git tag v4.0.1
-   git push origin v4.0.1
+   git tag v4.3.1
+   git push origin v4.3.1
 
    # GitHub Actions will automatically:
    # - Build Docker image
@@ -235,9 +227,9 @@ pytest tests/unit/test_wazuh_client.py -v
 ## 📝 Code Standards
 
 ### Python Code Style
-- **Black**: Code formatting (line length: 88)
-- **Ruff**: Linting and import sorting
-- **mypy**: Type checking
+- **Black**: Code formatting (line length: 120)
+- **Ruff**: Linting
+- **isort**: Import sorting (Black-compatible profile)
 - **Docstrings**: Google style for all public functions
 
 ### Git Commit Messages
@@ -290,7 +282,7 @@ When creating issues, use the appropriate template:
 Before asking for help:
 1. Check existing issues and discussions
 2. Review this contributing guide
-3. Check the USER_GUIDE.md for setup issues
+3. Check [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) for setup issues
 4. Review the code and tests for similar patterns
 
 ## 🏆 Recognition

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| 4.3.x   | Yes       |
+| 4.2.x   | Security fixes only |
+| < 4.2   | No        |
+
+## Reporting a Vulnerability
+
+Report vulnerabilities privately via [GitHub Security Advisories](https://github.com/gensecaihq/Wazuh-MCP-Server/security/advisories/new) ("Report a vulnerability" on the repository's Security tab). Do not open a public issue for security reports.
+
+Include what you can of the following:
+
+- Affected version(s) and deployment mode (stdio / remote HTTP, auth mode)
+- Reproduction steps or a proof of concept
+- Impact assessment (what an attacker gains)
+
+You can expect an acknowledgment within 72 hours and a fix or mitigation plan within 14 days for confirmed issues. Credit is given in the changelog and release notes unless you ask otherwise.
+
+## Scope
+
+In scope: authentication/authorization bypass (API key, OAuth 2.1, RBAC scopes), credential exposure in logs or responses, injection via tool parameters, SSRF through Wazuh connection settings, and container/deployment hardening gaps in the shipped configs.
+
+Out of scope: vulnerabilities in Wazuh itself (report to the [Wazuh project](https://github.com/wazuh/wazuh/security)), issues requiring a compromised host, and denial of service against your own deployment.
+
+## Hardening Guidance
+
+See [docs/security/README.md](docs/security/README.md) for deployment hardening: TLS, service accounts with least privilege, RBAC scopes, and network isolation.

--- a/docs/ADVANCED_FEATURES.md
+++ b/docs/ADVANCED_FEATURES.md
@@ -63,7 +63,7 @@ docker compose up -d
 REDIS_URL=redis://redis:6379/0
 SESSION_TTL_SECONDS=1800  # 30 minutes
 
-# Deploy with Redis
+# Deploy with Redis (create compose.redis.yml first — see Redis Setup below)
 docker compose -f compose.yml -f compose.redis.yml up -d
 ```
 
@@ -75,6 +75,8 @@ docker compose -f compose.yml -f compose.redis.yml up -d
 | ✅ Automatic session expiration |
 
 ### Redis Setup
+
+Create a `compose.redis.yml` overlay next to `compose.yml`:
 
 ```yaml
 # compose.redis.yml
@@ -95,16 +97,15 @@ volumes:
 
 ### Verification
 
-```bash
-# Check session storage mode
-curl http://localhost:3000/health | jq '.session_storage'
+The active session store is logged at startup:
 
-# Output:
-# {
-#   "type": "InMemorySessionStore"  # or "RedisSessionStore"
-#   "sessions_count": 5
-# }
+```bash
+docker compose logs wazuh-main-server | grep -i "SessionStore"
+# InMemorySessionStore: "Initialized InMemorySessionStore (single-instance mode)"
+# RedisSessionStore:    "RedisSessionStore configured with TTL=1800s"
 ```
+
+Redis itself can be checked with `docker compose exec redis redis-cli ping` (expects `PONG`).
 
 ---
 

--- a/docs/CLAUDE_INTEGRATION.md
+++ b/docs/CLAUDE_INTEGRATION.md
@@ -80,7 +80,7 @@ AUTH_MODE=bearer docker compose up -d
 
 **Step 1: Get API Key**
 ```bash
-docker compose logs wazuh-mcp-remote-server | grep "API key"
+docker compose logs wazuh-main-server | grep "API key"
 ```
 
 **Step 2: Exchange for JWT Token**

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -242,7 +242,7 @@ Environment variables:
 
 ```env
 # Rate limiting
-RATE_LIMIT_REQUESTS=200     # Requests per minute
+RATE_LIMIT_REQUESTS=200     # Requests allowed per window
 RATE_LIMIT_WINDOW=60        # Window in seconds
 
 # Session management

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -188,7 +188,7 @@ Indexer-backed tools require `WAZUH_INDEXER_HOST`. When it isn't configured, tho
 ## 🎨 Tool Development
 
 ### Adding New Tools
-See [Development Guide](../development/api.md) for creating custom MCP tools.
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for creating custom MCP tools.
 
 ### Tool Categories
 Tools are organized by functionality:
@@ -241,9 +241,9 @@ Each tool category has detailed documentation:
 - Performance optimization tips
 
 ### General API Issues
-- **Connection problems**: Check [Connection Troubleshooting](../troubleshooting/connection.md)
-- **Authentication errors**: See [Security Configuration](../security/auth.md)
-- **Performance issues**: Review [Performance Tuning](../troubleshooting/performance.md)
+- **Connection problems**: Check [Troubleshooting](../TROUBLESHOOTING.md)
+- **Authentication errors**: See [Security Documentation](../security/README.md)
+- **Performance issues**: Review [Operations Guide](../OPERATIONS.md)
 
 ---
 

--- a/docs/api/alerts.md
+++ b/docs/api/alerts.md
@@ -136,7 +136,7 @@ Get statistical summaries of alerts grouped by specified criteria.
 
 | Parameter | Type | Default | Required | Description |
 |-----------|------|---------|----------|-------------|
-| `time_range` | string | `"24h"` | No | Time range for analysis: 1h, 6h, 24h, 7d, 30d |
+| `time_range` | string | `"24h"` | No | Time range for analysis: `1h`, `6h`, `12h`, `1d`, `24h`, `7d`, `30d` |
 | `group_by` | string | `"rule.level"` | No | Field to group alerts by |
 
 ### Grouping Options

--- a/docs/api/log-management.md
+++ b/docs/api/log-management.md
@@ -213,9 +213,15 @@ Perform advanced search across all Wazuh security events and logs for threat hun
 
 | Parameter | Type | Default | Required | Description |
 |-----------|------|---------|----------|-------------|
-| `query` | string | - | **Yes** | Search query or pattern |
-| `time_range` | string | `"24h"` | No | Time range for event search |
+| `query` | string | - | **Yes** | Free-text search (Indexer `simple_query_string`: AND/OR/NOT, quoted phrases, trailing `*` prefix — no leading wildcards or regex) |
+| `time_range` | string | `"24h"` | No | Time range (`1h`, `6h`, `12h`, `1d`, `24h`, `7d`, `30d`) |
 | `limit` | integer | `100` | No | Maximum number of events to retrieve (1-1000) |
+| `rule_id` | string | `null` | No | Filter by rule ID |
+| `agent_id` | string | `null` | No | Filter by agent ID |
+| `level` | string | `null` | No | Minimum severity threshold (e.g. `10` or `10+`) |
+| `srcip` | string | `null` | No | Filter by source IP (`data.srcip`) |
+| `dstip` | string | `null` | No | Filter by destination IP (`data.dstip`) |
+| `compact` | boolean | `true` | No | Return compact results |
 
 ### Time Range Options
 
@@ -223,34 +229,23 @@ Perform advanced search across all Wazuh security events and logs for threat hun
 |-------|-------------|----------|
 | `1h` | Last hour | Real-time incident response |
 | `6h` | Last 6 hours | Recent activity analysis |
-| `24h` | Last 24 hours | Daily threat hunting |
+| `12h` | Last 12 hours | Shift handover review |
+| `1d` / `24h` | Last 24 hours | Daily threat hunting |
 | `7d` | Last week | Weekly security review |
 | `30d` | Last month | Historical analysis |
-| `90d` | Last quarter | Compliance reporting |
 
-### Advanced Search Capabilities
+### Query Syntax
 
-#### IP Address Search
-- IPv4: `192.168.1.100`
-- IPv6: `2001:db8::1`
-- CIDR ranges: `192.168.1.0/24`
-- Multiple IPs: `192.168.1.100 OR 10.0.0.5`
+The query runs through the Indexer's `simple_query_string` with a restricted grammar:
 
-#### Domain and URL Search
-- Domains: `malicious.com`
-- Subdomains: `*.suspicious.org`
-- URLs: `http://malicious.com/payload`
-- Protocol specific: `https://` 
+- **Supported**: terms (`failed login`), `AND` / `OR` / `NOT` operators, quoted phrases (`"wget http://malicious.com"`), trailing-`*` prefix matching (`ssh*`)
+- **Not supported**: leading wildcards (`*.suspicious.org`), regex, `field:value` targeting, CIDR ranges — use the `srcip`/`dstip`/`rule_id`/`agent_id` parameters for structured filtering instead
 
-#### User and Process Search
-- Usernames: `admin`, `root`, `service_account`
-- Process names: `cmd.exe`, `powershell.exe`, `bash`
-- Command lines: `"wget http://malicious.com"`
-
-#### File and Hash Search
-- File paths: `/etc/passwd`, `C:\Windows\System32\`
-- File names: `malware.exe`, `suspicious.dll`
-- Hash values: SHA256, MD5, SHA1 hashes
+#### Search Targets
+- IP addresses as literal terms: `192.168.1.100`, or `192.168.1.100 OR 10.0.0.5` — use `srcip`/`dstip` for field-precise matching
+- Domains and URLs: `malicious.com`, `"http://malicious.com/payload"`
+- Users and processes: `admin`, `powershell.exe`, `"wget http://malicious.com"`
+- File paths and hashes as literal terms: `/etc/passwd`, `malware.exe`, a full SHA256/MD5/SHA1 string
 
 ### Usage Examples
 

--- a/docs/api/vulnerabilities.md
+++ b/docs/api/vulnerabilities.md
@@ -20,8 +20,9 @@ Retrieve comprehensive vulnerability information from Wazuh with flexible filter
 | Parameter | Type | Default | Required | Description |
 |-----------|------|---------|----------|-------------|
 | `agent_id` | string | `null` | No | Filter by specific agent ID (3-8 alphanumeric characters) |
-| `severity` | string | `null` | No | Filter by severity level |
+| `severity` | string | `null` | No | Filter by severity level (`low`, `medium`, `high`, `critical`) |
 | `limit` | integer | `100` | No | Maximum number of vulnerabilities to retrieve (1-500) |
+| `compact` | boolean | `true` | No | Return compact results |
 
 ### Severity Levels
 
@@ -30,8 +31,7 @@ Retrieve comprehensive vulnerability information from Wazuh with flexible filter
 | `critical` | 9.0-10.0 | Immediate | Emergency patching within 24-48 hours |
 | `high` | 7.0-8.9 | High | Patch within 7-14 days |
 | `medium` | 4.0-6.9 | Medium | Patch within 30-60 days |
-| `low` | 0.1-3.9 | Low | Patch during maintenance windows |
-| `informational` | 0.0 | Informational | Monitor, no immediate action required |
+| `low` | 0.0-3.9 | Low | Patch during maintenance windows |
 
 ### Usage Examples
 
@@ -116,8 +116,7 @@ This queries:
       "critical": 12,
       "high": 34,
       "medium": 78,
-      "low": 32,
-      "informational": 0
+      "low": 32
     },
     "by_status": {
       "open": 140,
@@ -158,6 +157,7 @@ Retrieve only critical vulnerabilities requiring immediate attention.
 | Parameter | Type | Default | Required | Description |
 |-----------|------|---------|----------|-------------|
 | `limit` | integer | `50` | No | Maximum number of critical vulnerabilities to retrieve (1-500) |
+| `compact` | boolean | `true` | No | Return compact results |
 
 ### Usage Examples
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,7 +38,7 @@ The Manager API is always reached over HTTPS on `WAZUH_PORT` (it is TLS-only).
 |----------|---------|-------------|
 | `WAZUH_PORT` | `55000` | Manager API port |
 | `WAZUH_VERIFY_SSL` | `true` | Verify the Manager's TLS certificate. Set `false` only for self-signed certs in development |
-| `WAZUH_ALLOW_SELF_SIGNED` | `false` | Explicitly allow self-signed Manager certificates |
+| `WAZUH_ALLOW_SELF_SIGNED` | `true` | Accept self-signed Manager certificates (Wazuh ships with them by default). Set `false` in production with a proper CA |
 
 ## Wazuh Indexer
 

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -49,30 +49,22 @@ Wazuh MCP Server implements multiple layers of security:
 
 ### Wazuh Server Authentication
 
-#### Basic Authentication (Default)
+The server authenticates to the Wazuh Manager API with a username and password:
+
 ```bash
 # .env
-WAZUH_AUTH_TYPE=basic
 WAZUH_USER=secure-service-account
 WAZUH_PASS=complex-password-123!@#
 ```
 
+Internally, the client exchanges these credentials at `/security/user/authenticate` for
+the Wazuh API's short-lived JWT and refreshes it automatically on expiry — the long-lived
+password is sent only at (re-)authentication, never on every request.
+
 **Security Requirements:**
-- Use dedicated service account
+- Use a dedicated service account (below), not the built-in `wazuh` admin user
 - Strong password (12+ characters, mixed case, numbers, symbols)
 - Regular password rotation (90 days recommended)
-
-#### JWT Token Authentication (Recommended)
-```bash
-# .env
-WAZUH_AUTH_TYPE=jwt
-WAZUH_JWT_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
-```
-
-**Security Benefits:**
-- Short-lived tokens (configurable expiration)
-- Automatic token refresh
-- Reduced credential exposure
 
 ### Service Account Configuration
 
@@ -129,14 +121,15 @@ server itself honors are for its **outbound** connections to Wazuh:
 
 ```bash
 # .env — outbound TLS to the Wazuh Manager / Indexer
-WAZUH_VERIFY_SSL=true            # verify the Manager cert (default)
-WAZUH_ALLOW_SELF_SIGNED=false    # allow a self-signed Manager cert
-WAZUH_INDEXER_VERIFY_SSL=true    # verify the Indexer cert (default)
+WAZUH_VERIFY_SSL=true            # verify the Manager cert (default: true)
+WAZUH_ALLOW_SELF_SIGNED=false    # default: true (accepts Wazuh's stock self-signed certs);
+                                 # set false in production with a proper CA
+WAZUH_INDEXER_VERIFY_SSL=true    # verify the Indexer cert (default: true)
 WAZUH_INDEXER_SSL=true           # use HTTPS to the Indexer
 ```
 
-For inbound TLS hardening, see your reverse proxy's documentation (a sample is in
-`docs/nginx-reverse-proxy.conf`).
+For inbound TLS hardening (certificates, minimum TLS version, cipher suites, HSTS),
+see your reverse proxy's documentation — e.g. nginx, Caddy, or Traefik.
 
 ### Certificate Best Practices
 
@@ -301,17 +294,24 @@ rsyslog -f /etc/rsyslog.d/wazuh-mcp.conf
 
 ### Health Checks
 
-#### Security Health Validation
+#### Health Validation
 ```bash
-# Run security-focused health check
 curl http://localhost:3000/health
-
-# Expected security checks:
-# ✅ ssl_config: SSL verification enabled
-# ✅ credentials: Secure credential storage
-# ✅ permissions: Proper file permissions
-# ✅ audit_logging: Audit logging enabled
 ```
+
+```json
+{
+  "status": "healthy",
+  "timestamp": "2026-08-08T12:00:00Z",
+  "version": "4.3.0",
+  "mcp_protocol_version": "2025-11-25",
+  "supported_protocol_versions": ["2026-07-28", "2025-11-25", "2025-06-18", "2025-03-26", "2024-11-05"]
+}
+```
+
+The endpoint reports liveness only. Verify the security posture directly: TLS settings
+via your `.env` (`WAZUH_VERIFY_SSL`, `WAZUH_ALLOW_SELF_SIGNED`), file permissions with
+`ls -la .env`, and auth events in the structured logs.
 
 ### Threat Detection
 
@@ -329,7 +329,7 @@ curl http://localhost:3000/health
 ```bash
 # Security alerts
 if grep -q "authentication.*failure" logs/security-audit.log; then
-    echo "ALERT: Authentication failures detected" | mail -s "Security Alert" admin@company.com
+    echo "ALERT: Authentication failures detected" | mail -s "Security Alert" soc@example.com
 fi
 ```
 
@@ -408,9 +408,9 @@ echo "Running Wazuh MCP Server security scan..."
 echo "Checking file permissions..."
 find . -name "*.env" -exec ls -la {} \;
 
-# Check TLS configuration
+# Check TLS configuration (verify the Wazuh Manager presents a valid cert)
 echo "Testing TLS configuration..."
-python tools/validate_setup.py --test-ssl
+openssl s_client -connect "${WAZUH_HOST:-localhost}:55000" -brief </dev/null
 
 # Check for secrets in files
 echo "Scanning for hardcoded secrets..."
@@ -439,7 +439,7 @@ sudo ufw deny in 55000/tcp    # Block incoming
 ## 📞 Security Support
 
 ### Security Issues
-- **Security vulnerabilities**: Report privately to security@company.com
+- **Security vulnerabilities**: Report privately via [GitHub Security Advisories](https://github.com/gensecaihq/Wazuh-MCP-Server/security/advisories/new) — see [SECURITY.md](../../SECURITY.md)
 - **Configuration issues**: Check [Configuration Guide](../configuration.md)
 - **Incident response**: Follow documented procedures
 

--- a/src/wazuh_mcp_server/server.py
+++ b/src/wazuh_mcp_server/server.py
@@ -1681,7 +1681,7 @@ async def handle_tools_list(params: Dict[str, Any], session: MCPSession) -> Dict
     Filters tools based on session token scopes."""
     _cursor = params.get("cursor")  # Reserved for future pagination
     tools = [
-        # Alert Management Tools (4 tools)
+        # Alert Management Tools (5 tools)
         {
             "name": "get_wazuh_alerts",
             "description": "Retrieve Wazuh security alerts with optional filtering",
@@ -1783,13 +1783,13 @@ async def handle_tools_list(params: Dict[str, Any], session: MCPSession) -> Dict
         },
         {
             "name": "search_security_events",
-            "description": "Search for specific security events across all Wazuh data. Supports free-text search (Lucene syntax: AND, OR, NOT, field:value, wildcards, quoted phrases) and structured field filters. All filters are combined with AND logic.",
+            "description": "Search for specific security events across all Wazuh data. Supports free-text search (simple query syntax: AND, OR, NOT, quoted phrases, trailing-* prefix; no leading wildcards, regex, or field:value) and structured field filters. All filters are combined with AND logic.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
                     "query": {
                         "type": "string",
-                        "description": "Free-text search query (Lucene syntax: AND, OR, NOT, field:value, wildcards, quoted phrases). Searched across all alert fields via Elasticsearch query_string.",
+                        "description": "Free-text search query (AND, OR, NOT, quoted phrases, trailing-* prefix; leading wildcards, regex, and field:value are not supported — use the structured filter parameters instead). Searched across all alert fields via Elasticsearch simple_query_string.",
                     },
                     "time_range": {
                         "type": "string",
@@ -1927,7 +1927,7 @@ async def handle_tools_list(params: Dict[str, Any], session: MCPSession) -> Dict
                 "required": [],
             },
         },
-        # Security Analysis Tools (6 tools)
+        # Security Analysis Tools (7 tools)
         {
             "name": "analyze_security_threat",
             "description": "Analyze a security threat indicator using AI-powered analysis",


### PR DESCRIPTION
Systematic audit of every doc against the code. Highlights:

- **docs/security/README.md** documented `WAZUH_AUTH_TYPE`/`WAZUH_JWT_TOKEN` options that don't exist anywhere in the code — a user following the "recommended" JWT section ended up with a non-functional config. Replaced with the real flow (basic credentials exchanged internally for the Wazuh API JWT).
- `WAZUH_ALLOW_SELF_SIGNED` documented as default `false` in two docs; code default is `true` (config.py:192). Docs now state the true default and recommend `false` for production.
- **log-management.md** claimed CIDR ranges, leading-wildcard subdomains, and a `90d` time range for `search_security_events` — none supported (the implementation is a restricted `simple_query_string`; enum has no `90d`). The tool's registration description in server.py had the same stale Lucene claims, which is what the LLM actually reads — fixed both.
- v4.3.0 changelog said 54 tools; actual count is 55 (verified against `handle_tools_list`: 5+6+3+7+5+10+9+5+5).
- Added root **SECURITY.md** (was missing; GitHub had no security policy to surface).
- CONTRIBUTING.md fixes: Python 3.11+ baseline, `pip install -e ".[dev]"`, real test tree (`tests/integration/` only), coverage floor per pyproject instead of an aspirational 90%, Black line length 120, actual workflow list, removed pointers to INSTALLATION.md/USER_GUIDE.md which don't exist.
- Fixed fabricated `/health` payloads in two docs, a wrong compose service name, 4 broken links in the API index, and the invalid `informational` severity in vulnerabilities.md.

Verified: 55 tools / 14 write / 5 prompts confirmed against code; black+ruff clean; py_compile passes; agents.md, security-analysis.md, system-monitoring.md, compliance-reporting.md, MULTI_CLUSTER.md, TROUBLESHOOTING.md, OPERATIONS.md, UPGRADING.md audited clean.