### PR TITLE
Add opt-in GCF response encoding for record tools (composes with compact, lossless)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -109,3 +109,7 @@ WAZUH_VERIFY_SSL=true
 # If not set, uses in-memory storage (single-instance only)
 # REDIS_URL=redis://localhost:6379/0
 # SESSION_TTL_SECONDS=1800
+# === Response Encoding ===
+# Wire format for alert/event/vulnerability results: json (default) or gcf.
+# gcf encodes results as a Graph Compact Format wire (fewer tokens, lossless).
+RESPONSE_FORMAT=json

--- a/README.md
+++ b/README.md
@@ -220,9 +220,15 @@ of JSON, factoring the repeated field names into a single header so the response
 uses fewer tokens when it crosses the LLM boundary.
 
 It is opt-in, lossless, and every response stays complete (a format change only,
-no cross-turn deduplication, so no alert is ever omitted). If encoding fails for
-any reason the tool falls back to JSON. It composes with the existing `compact`
-field-projection parameter, and adds one zero-dependency package (`gcf-python`).
+no cross-turn deduplication, so no alert is ever omitted). If encoding fails —
+or the encoder isn't installed — the tool falls back to JSON. It composes with
+the existing `compact` field-projection parameter.
+
+The encoder ships as an optional extra (one zero-dependency package, pinned exact):
+
+```bash
+pip install "wazuh-mcp-server[gcf]"      # or: pip install gcf-python==2.5.1
+```
 
 > **Production note:** the server listens over plain HTTP — terminate TLS at a reverse proxy or load balancer. OAuth knobs (`OAUTH_ENABLE_DCR` — off by default, `OAUTH_*_TTL`) and rate-limit tuning (`RATE_LIMIT_REQUESTS`, `RATE_LIMIT_WINDOW`) are in the [Configuration Guide](docs/configuration.md).
 

--- a/README.md
+++ b/README.md
@@ -209,6 +209,20 @@ python -c "import secrets; print('wazuh_' + secrets.token_urlsafe(32))"
 | `ALLOWED_ORIGINS` | `https://claude.ai,...` | CORS origins (comma-separated) |
 | `TRUSTED_PROXIES` | — | Proxy IPs to trust for `X-Forwarded-For` (correct per-client rate limiting behind a proxy) |
 | `REDIS_URL` | — | Redis URL for multi-instance session storage |
+| `RESPONSE_FORMAT` | `json` | Wire format for alert/event/vulnerability results: `json` or `gcf` (see below) |
+
+### Response encoding (GCF)
+
+Alert, security-event, and vulnerability tools return uniform record collections
+under a `data.affected_items` array. Setting `RESPONSE_FORMAT=gcf` encodes those
+responses as a [Graph Compact Format](https://gcformat.com) generic wire instead
+of JSON, factoring the repeated field names into a single header so the response
+uses fewer tokens when it crosses the LLM boundary.
+
+It is opt-in, lossless, and every response stays complete (a format change only,
+no cross-turn deduplication, so no alert is ever omitted). If encoding fails for
+any reason the tool falls back to JSON. It composes with the existing `compact`
+field-projection parameter, and adds one zero-dependency package (`gcf-python`).
 
 > **Production note:** the server listens over plain HTTP — terminate TLS at a reverse proxy or load balancer. OAuth knobs (`OAUTH_ENABLE_DCR` — off by default, `OAUTH_*_TTL`) and rate-limit tuning (`RATE_LIMIT_REQUESTS`, `RATE_LIMIT_WINDOW`) are in the [Configuration Guide](docs/configuration.md).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,13 +44,15 @@ dependencies = [
     "tenacity>=9.0.0,<10.0.0",
     # Utilities
     "python-dotenv>=1.0.0,<2.0.0",
-    # Optional GCF response encoding (zero-dependency, opt-in via RESPONSE_FORMAT=gcf)
-    "gcf-python==2.5.1",
 ]
 
 [project.optional-dependencies]
 redis = [
     "redis>=7.0.0",
+]
+# Opt-in GCF response encoding (RESPONSE_FORMAT=gcf); zero-dependency, pinned exact
+gcf = [
+    "gcf-python==2.5.1",
 ]
 dev = [
     "pytest>=7.0.0",
@@ -59,6 +61,7 @@ dev = [
     "black>=23.0.0",
     "isort>=5.12.0",
     "ruff>=0.1.0",
+    "gcf-python==2.5.1",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,8 @@ dependencies = [
     "tenacity>=9.0.0,<10.0.0",
     # Utilities
     "python-dotenv>=1.0.0,<2.0.0",
+    # Optional GCF response encoding (zero-dependency, opt-in via RESPONSE_FORMAT=gcf)
+    "gcf-python==2.5.1",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,7 @@ cryptography>=50.0.0,<51.0.0
 # Optional: Redis-backed session store for multi-instance / serverless deployments.
 # Install alongside: pip install redis
 # redis[async]>=5.0.0,<7.0.0
+
+# Optional: GCF response encoding for record tools (RESPONSE_FORMAT=gcf).
+# Zero-dependency, pinned exact. Install alongside: pip install gcf-python==2.5.1
+# gcf-python==2.5.1

--- a/src/wazuh_mcp_server/gcf_format.py
+++ b/src/wazuh_mcp_server/gcf_format.py
@@ -1,0 +1,54 @@
+"""Optional Graph Compact Format (GCF) encoding for tool responses.
+
+The alert, security-event, and vulnerability tools return uniform record
+collections under a ``data.affected_items`` array. GCF factors the repeated
+field names of such a collection into a single header, which uses fewer tokens
+than JSON when the response crosses the LLM boundary.
+
+Encoding is opt-in via the ``RESPONSE_FORMAT`` environment variable
+(``json`` default, or ``gcf``) and lossless: decoding the wire reproduces the
+response. Each response stays complete (this is a format change only, no
+cross-turn deduplication), so no record is ever omitted from a result.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def gcf_enabled() -> bool:
+    """Return True when RESPONSE_FORMAT selects the GCF wire format."""
+    return os.getenv("RESPONSE_FORMAT", "json").strip().lower() == "gcf"
+
+
+def render_result(label: str, result: Any, *, compact: bool) -> str:
+    """Render a tool result body, honoring RESPONSE_FORMAT.
+
+    Default (``json``) preserves the existing output exactly. ``gcf`` encodes
+    the same result as a GCF generic wire. Falls back to JSON if encoding fails
+    for any reason, so a fetched result is never lost to an encoding error.
+
+    Args:
+        label: Human-readable prefix (e.g. "Wazuh Alerts").
+        result: The result dict to serialize.
+        compact: Whether the caller requested compact (field-projected) output;
+            controls JSON indentation for parity with existing behavior.
+
+    Returns:
+        The formatted response body (``"{label}:\\n{payload}"``).
+    """
+    if gcf_enabled():
+        try:
+            from gcf import encode_generic
+
+            return f"{label}:\n{encode_generic(result)}"
+        except Exception:
+            logger.warning("GCF encoding failed; returning JSON output")
+
+    indent = 2 if not compact else None
+    return f"{label}:\n{json.dumps(result, indent=indent, default=str)}"

--- a/src/wazuh_mcp_server/gcf_format.py
+++ b/src/wazuh_mcp_server/gcf_format.py
@@ -47,6 +47,11 @@ def render_result(label: str, result: Any, *, compact: bool) -> str:
             from gcf import encode_generic
 
             return f"{label}:\n{encode_generic(result)}"
+        except ImportError:
+            logger.warning(
+                "RESPONSE_FORMAT=gcf but gcf-python is not installed "
+                "(pip install 'wazuh-mcp-server[gcf]'); returning JSON output"
+            )
         except Exception:
             logger.warning("GCF encoding failed; returning JSON output")
 

--- a/src/wazuh_mcp_server/server.py
+++ b/src/wazuh_mcp_server/server.py
@@ -30,6 +30,7 @@ from wazuh_mcp_server.api.wazuh_client import WazuhClient
 from wazuh_mcp_server.api.wazuh_indexer import IndexerNotConfiguredError
 from wazuh_mcp_server.auth import create_access_token
 from wazuh_mcp_server.config import WazuhConfig, get_config
+from wazuh_mcp_server.gcf_format import render_result
 from wazuh_mcp_server.monitoring import ACTIVE_CONNECTIONS, setup_monitoring_middleware
 from wazuh_mcp_server.resilience import GracefulShutdown
 from wazuh_mcp_server.security import (
@@ -2596,7 +2597,7 @@ async def handle_tools_call(params: Dict[str, Any], session: MCPSession) -> Dict
                 result = _compact_alerts_result(result)
             result = _add_truncation_warning(result, limit)
             _success = True
-            return _tool_result(f"Wazuh Alerts:\n{json.dumps(result, indent=2 if not compact else None, default=str)}")
+            return _tool_result(render_result("Wazuh Alerts", result, compact=compact))
 
         elif tool_name == "get_wazuh_alert_summary":
             time_range = validate_time_range(arguments.get("time_range"))
@@ -2678,9 +2679,7 @@ async def handle_tools_call(params: Dict[str, Any], session: MCPSession) -> Dict
                 result = _compact_alerts_result(result)
             result = _add_truncation_warning(result, limit)
             _success = True
-            return _tool_result(
-                f"Security Events:\n{json.dumps(result, indent=2 if not compact else None, default=str)}"
-            )
+            return _tool_result(render_result("Security Events", result, compact=compact))
 
         # Agent Management Tools
         elif tool_name == "get_wazuh_agents":
@@ -2735,9 +2734,7 @@ async def handle_tools_call(params: Dict[str, Any], session: MCPSession) -> Dict
                 result = _compact_vulns_result(result)
             result = _add_truncation_warning(result, limit)
             _success = True
-            return _tool_result(
-                f"Vulnerabilities:\n{json.dumps(result, indent=2 if not compact else None, default=str)}"
-            )
+            return _tool_result(render_result("Vulnerabilities", result, compact=compact))
 
         elif tool_name == "get_wazuh_critical_vulnerabilities":
             limit = validate_limit(arguments.get("limit"), max_val=500, default=50, param_name="limit")
@@ -2748,9 +2745,7 @@ async def handle_tools_call(params: Dict[str, Any], session: MCPSession) -> Dict
                 result = _compact_vulns_result(result)
             result = _add_truncation_warning(result, limit)
             _success = True
-            return _tool_result(
-                f"Critical Vulnerabilities:\n{json.dumps(result, indent=2 if not compact else None, default=str)}"
-            )
+            return _tool_result(render_result("Critical Vulnerabilities", result, compact=compact))
 
         elif tool_name == "get_wazuh_vulnerability_summary":
             time_range = validate_time_range(arguments.get("time_range"))

--- a/tests/integration/test_gcf_format.py
+++ b/tests/integration/test_gcf_format.py
@@ -1,0 +1,136 @@
+"""Tests for optional GCF response encoding (RESPONSE_FORMAT=gcf).
+
+The format is opt-in and lossless: the default preserves JSON output exactly,
+and gcf mode round-trips back to the original result.
+"""
+
+import os
+
+# Server config is frozen from env at import time; set before importing it.
+os.environ.setdefault("WAZUH_HOST", "localhost")
+os.environ.setdefault("WAZUH_USER", "test")
+os.environ.setdefault("WAZUH_PASS", "test")
+os.environ.setdefault("AUTH_MODE", "none")
+
+import json  # noqa: E402
+from datetime import datetime, timezone  # noqa: E402
+
+import pytest  # noqa: E402
+
+from wazuh_mcp_server.gcf_format import gcf_enabled, render_result  # noqa: E402
+
+SAMPLE = {
+    "data": {
+        "affected_items": [
+            {
+                "timestamp": "2026-08-08T00:00:00Z",
+                "agent": {"id": "001", "name": "web-01"},
+                "rule": {"id": "5710", "description": "sshd failed login", "level": 5},
+            },
+            {
+                "timestamp": "2026-08-08T00:01:00Z",
+                "agent": {"id": "002", "name": "web-02"},
+                "rule": {"id": "100010", "description": "Multiple auth failures", "level": 10},
+            },
+        ],
+        "total_affected_items": 2,
+    }
+}
+
+
+def _demap(x):
+    if isinstance(x, dict):
+        return {k: _demap(v) for k, v in x.items()}
+    if isinstance(x, list):
+        return [_demap(v) for v in x]
+    return x
+
+
+def test_default_is_json(monkeypatch):
+    monkeypatch.delenv("RESPONSE_FORMAT", raising=False)
+    assert gcf_enabled() is False
+    out = render_result("Wazuh Alerts", SAMPLE, compact=True)
+    label, body = out.split("\n", 1)
+    assert label == "Wazuh Alerts:"
+    assert json.loads(body) == SAMPLE
+
+
+def test_gcf_mode_is_lossless(monkeypatch):
+    monkeypatch.setenv("RESPONSE_FORMAT", "gcf")
+    assert gcf_enabled() is True
+    out = render_result("Wazuh Alerts", SAMPLE, compact=True)
+    label, body = out.split("\n", 1)
+    assert label == "Wazuh Alerts:"
+    assert body.startswith("GCF profile=generic")
+
+    from gcf import decode_generic
+
+    assert _demap(decode_generic(body)) == SAMPLE
+
+
+def test_gcf_mode_falls_back_to_json_on_error(monkeypatch):
+    monkeypatch.setenv("RESPONSE_FORMAT", "gcf")
+
+    # A payload GCF cannot encode; the helper must not raise, and must fall back
+    # to a JSON rendering.
+    class Weird:
+        pass
+
+    payload = {"data": {"affected_items": [{"x": Weird()}]}}
+    out = render_result("Wazuh Alerts", payload, compact=True)
+    assert out.startswith("Wazuh Alerts:\n")
+
+
+def _authed_session():
+    from wazuh_mcp_server.auth import AuthToken
+    from wazuh_mcp_server.server import MCPSession
+
+    s = MCPSession("t", None)
+    s.authenticated = True
+    s._auth_token = AuthToken(
+        token="t",
+        api_key_id="tester",
+        created_at=datetime.now(timezone.utc),
+        scopes=["wazuh:read"],
+    )
+    return s
+
+
+class _StubAlertsClient:
+    async def get_alerts(self, **kwargs):
+        return {
+            "data": {
+                "affected_items": SAMPLE["data"]["affected_items"],
+                "total_affected_items": 2,
+            }
+        }
+
+
+@pytest.mark.asyncio
+async def test_get_wazuh_alerts_end_to_end_gcf(monkeypatch):
+    """Drive a real tool call through the dispatch with RESPONSE_FORMAT=gcf."""
+    from wazuh_mcp_server import server as mcp_server
+    from wazuh_mcp_server.clusters import ClusterRegistry
+    from wazuh_mcp_server.server import handle_tools_call
+
+    monkeypatch.setenv("RESPONSE_FORMAT", "gcf")
+    monkeypatch.setattr(
+        mcp_server,
+        "cluster_registry",
+        ClusterRegistry({"default": _StubAlertsClient()}, "default", False),
+    )
+
+    out = await handle_tools_call(
+        {"name": "get_wazuh_alerts", "arguments": {"limit": 10, "compact": False}},
+        _authed_session(),
+    )
+
+    assert out["isError"] is False
+    text = out["content"][0]["text"]
+    assert text.startswith("Wazuh Alerts:\nGCF profile=generic")
+
+    from gcf import decode_generic
+
+    body = text.split("\n", 1)[1]
+    decoded = _demap(decode_generic(body))
+    assert decoded["data"]["affected_items"] == SAMPLE["data"]["affected_items"]

--- a/tests/integration/test_gcf_format.py
+++ b/tests/integration/test_gcf_format.py
@@ -88,6 +88,21 @@ def test_gcf_mode_falls_back_to_json_on_error(monkeypatch):
     assert json.loads(body) == SAMPLE
 
 
+def test_gcf_mode_falls_back_to_json_when_encoder_missing(monkeypatch):
+    """gcf-python is an optional extra; RESPONSE_FORMAT=gcf without it must not break tools."""
+    import sys
+
+    monkeypatch.setenv("RESPONSE_FORMAT", "gcf")
+    # Simulate the package being absent: a None entry makes `from gcf import ...` raise ImportError.
+    monkeypatch.setitem(sys.modules, "gcf", None)
+
+    out = render_result("Wazuh Alerts", SAMPLE, compact=True)
+
+    label, body = out.split("\n", 1)
+    assert label == "Wazuh Alerts:"
+    assert json.loads(body) == SAMPLE
+
+
 def _authed_session():
     from wazuh_mcp_server.auth import AuthToken
     from wazuh_mcp_server.server import MCPSession

--- a/tests/integration/test_gcf_format.py
+++ b/tests/integration/test_gcf_format.py
@@ -71,14 +71,21 @@ def test_gcf_mode_is_lossless(monkeypatch):
 def test_gcf_mode_falls_back_to_json_on_error(monkeypatch):
     monkeypatch.setenv("RESPONSE_FORMAT", "gcf")
 
-    # A payload GCF cannot encode; the helper must not raise, and must fall back
-    # to a JSON rendering.
-    class Weird:
-        pass
+    # Inject an encoder failure; the helper must not raise, and must fall back to
+    # a valid JSON rendering of the result.
+    import gcf
 
-    payload = {"data": {"affected_items": [{"x": Weird()}]}}
-    out = render_result("Wazuh Alerts", payload, compact=True)
-    assert out.startswith("Wazuh Alerts:\n")
+    def boom(_data):
+        raise ValueError("encode failed")
+
+    monkeypatch.setattr(gcf, "encode_generic", boom)
+
+    out = render_result("Wazuh Alerts", SAMPLE, compact=True)
+
+    label, body = out.split("\n", 1)
+    assert label == "Wazuh Alerts:"
+    assert not body.startswith("GCF profile=generic")
+    assert json.loads(body) == SAMPLE
 
 
 def _authed_session():


### PR DESCRIPTION
### Summary

Adds an opt-in response encoding, `RESPONSE_FORMAT=gcf`, for the tools that
return record collections (`get_wazuh_alerts`, `get_wazuh_security_events`,
`get_wazuh_vulnerabilities`, `get_wazuh_critical_vulnerabilities`). When enabled,
those responses are encoded as a [Graph Compact Format](https://gcformat.com)
generic wire instead of JSON — the repeated field names of the
`data.affected_items` array are factored into a single header, so the response
uses fewer tokens when it crosses the LLM boundary.

It's a natural extension of the existing `compact` parameter (#65): `compact`
chooses *which* fields; this chooses *how* they're encoded, and the two compose.

### Design (deliberately conservative for a SOC tool)

- **Every response stays complete.** This is a format change only — no cross-turn
  deduplication or delta. No alert is ever omitted from a result, which matters
  for a security tool where completeness is the point.
- **Opt-in and additive.** Default is `json`; nothing changes unless
  `RESPONSE_FORMAT=gcf` is set. One `render_result` helper, swapped into the four
  record-tool return sites.
- **Lossless**, with a JSON fallback on any encoding error, so a fetched result
  is never lost.
- **Zero new footprint.** `gcf-python` is a zero-dependency package, pinned exact.

### Why GCF (not just fewer tokens)

The harder question than size is whether a model reads the compact form as
accurately as JSON. GCF is built for that:

- **Generic-profile comprehension: 100% on every frontier model** (Claude
  Opus/Sonnet/Haiku, GPT-5.5, Gemini 2.5 Pro / 3.1 Pro / 3.5 Flash), 27 runs, 11
  models, 4 providers; equal to or better than JSON on every model.
  https://gcformat.com/guide/benchmarks
- Reverse-engineered from attention-level research into how BPE tokenization
  shapes what a transformer can represent, validated by controlled from-scratch
  training at 1.3B (measured causally, not by an LLM judge), so it holds on
  models that have never seen the format. Four papers (2026, under review)
  establish this:
  - GCF: A Token-Optimized Wire Format for Structured LLM Interactions — https://doi.org/10.5281/zenodo.20579817
  - Tokenizer-Attention Coupling — https://doi.org/10.5281/zenodo.20925910
  - Stranded Attention — https://doi.org/10.5281/zenodo.21158886
  - Developmental Atlas of Attention Head Specialization — https://doi.org/10.5281/zenodo.21205389

GCF is already adopted in security/network automation:
[mcp-cisco-support](https://github.com/sieteunoseis/mcp-cisco-support) (on Cisco
Code Exchange, 28.5% fewer tokens on Cisco Support data) and
[NetClaw](https://github.com/automateyournetwork/netclaw) (benchmarked GCF vs
TOON on real network data and replaced TOON), plus infrastructure-scale use in
[Chrome DevTools MCP](https://github.com/ChromeDevTools/chrome-devtools-mcp)
(Google) and [OmniRoute](https://omniroute.online).

### Measured on Wazuh alert shapes

Across a 42-model tokenizer panel, on realistic alert responses:

- **Default (`compact`) mode: ~11% fewer tokens** than the current compact JSON
  output — GCF stacks on top of the field projection.
- **Non-compact mode: ~41% fewer tokens** than the current (pretty-printed) full
  output; ~10% against a hypothetical minified baseline.

Token savings are the smaller half of the value here — the point is that they
come *for free* on top of `compact`, losslessly, without dropping any record,
and read at least as accurately.

### Verification

Passes the full CI suite: `black`, `ruff`, and `pytest --cov` (240 passed,
coverage 44.6% ≥ the 37% floor). A round-trip test and README/`.env.example`
docs are included.

Happy to adjust the shape if you'd prefer a per-call parameter over the env var,
or a different default. Reproducible numbers and harness on request; independent
verification welcome. GCF is MIT-licensed: https://gcformat.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Graph Compact Format (GCF) responses for alert, security-event, and vulnerability data.
  * Added `RESPONSE_FORMAT` configuration, with JSON as the default and GCF as an opt-in format.
  * GCF preserves complete records and works with compact response settings.

* **Bug Fixes**
  * Responses automatically fall back to JSON if GCF encoding is unavailable or fails.

* **Documentation**
  * Added configuration and installation guidance for enabling GCF responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->