### PR TITLE
fix(ci): make GCF tests skip without the optional [gcf] extra (follow-up to #102)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e .
+        pip install -e ".[gcf]"
         pip install pytest pytest-asyncio pytest-cov
 
     - name: Run tests

--- a/tests/integration/test_gcf_format.py
+++ b/tests/integration/test_gcf_format.py
@@ -56,6 +56,7 @@ def test_default_is_json(monkeypatch):
 
 
 def test_gcf_mode_is_lossless(monkeypatch):
+    pytest.importorskip("gcf")  # optional [gcf] extra; skip when not installed
     monkeypatch.setenv("RESPONSE_FORMAT", "gcf")
     assert gcf_enabled() is True
     out = render_result("Wazuh Alerts", SAMPLE, compact=True)
@@ -69,6 +70,7 @@ def test_gcf_mode_is_lossless(monkeypatch):
 
 
 def test_gcf_mode_falls_back_to_json_on_error(monkeypatch):
+    pytest.importorskip("gcf")  # optional [gcf] extra; skip when not installed
     monkeypatch.setenv("RESPONSE_FORMAT", "gcf")
 
     # Inject an encoder failure; the helper must not raise, and must fall back to
@@ -131,6 +133,7 @@ class _StubAlertsClient:
 @pytest.mark.asyncio
 async def test_get_wazuh_alerts_end_to_end_gcf(monkeypatch):
     """Drive a real tool call through the dispatch with RESPONSE_FORMAT=gcf."""
+    pytest.importorskip("gcf")  # optional [gcf] extra; skip when not installed
     from wazuh_mcp_server import server as mcp_server
     from wazuh_mcp_server.clusters import ClusterRegistry
     from wazuh_mcp_server.server import handle_tools_call


### PR DESCRIPTION
Moving `gcf-python` from a core dependency to the optional `[gcf]` extra in #102
was the right call: a default install shouldn't pull a third-party package for an
opt-in feature. That dependency change is what makes this follow-up necessary.
With `gcf-python` now optional, the encoder-dependent tests can no longer assume
the package is present, and the CI test job installs `pip install -e .` (without
the extra), so those tests currently fail at collection on `main`.

This PR completes the optional-extra change on the test and CI side:

- Guards the three encoder-dependent tests with `pytest.importorskip("gcf")`, so
  they skip cleanly when the extra isn't installed (a plain `pip install -e .`
  stays green).
- Installs the `[gcf]` extra in the CI test job so the tests are actually
  exercised there rather than skipped.

Verified both ways: without the extra, the suite passes with those three skipped
(coverage stays above the floor); with `[gcf]`, all GCF tests run and pass.
Signed off per DCO.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by enabling optional GCF support in the test environment.
  * GCF-specific tests now skip gracefully when the optional package is unavailable.
  * Existing fallback behavior continues to be verified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->