### PR TITLE
fix: AR verification reports correctly + reporting/threat-score correctness

### DIFF
--- a/docs/AUDIT_FINDINGS.md
+++ b/docs/AUDIT_FINDINGS.md
@@ -69,25 +69,44 @@ rotation, and the dual-era MCP protocol negotiation.
   before the client check, so a wrong-id request permanently killed a legitimate grant. Now
   validated before consumption; the token is restored for a correct retry.
 
-## Deferred (tracked, not addressed here)
+## Fixed in follow-up (verification & correctness)
 
-These are real but need larger design changes or are lower-impact; grouped for follow-up.
+- **Active-Response verification queries now use structured filters.** `check_blocked_ip`,
+  `check_agent_isolation`, and `check_user_status` built free-text `"X AND Y"` queries that route
+  through `simple_query_string` (where `AND` is a literal term with `default_operator=AND`) and so
+  reliably matched nothing — the verification layer for the state-changing tools reported false
+  negatives. Now they use `srcip`/`rule_groups`/`agent_id`/time-bounded filters. `check_agent_isolation`
+  no longer equates "disconnected" with "isolated" (Wazuh host-isolation keeps the manager link).
+- **`check_process`** queries the specific PID instead of paging the first 500 processes (a
+  still-running target beyond the page was reported killed) and surfaces the inventory scan time.
+- **`check_file_quarantine`** no longer false-positives on any path containing the substring
+  "quarantine"; it keys off a FIM deletion of the exact path.
+- **`get_sca_policy_checks` score** counts applicable checks only (was `passed/total`, so 50 passed
+  + 50 N/A read as 50%).
+- **`get_top_security_threats` ranking** no longer saturates — severity is weighted highest, so a
+  chatty level-3 rule no longer outranks a targeted level-15 attack.
+- **Tool descriptions** corrected where they overstated capability (`analyze_security_threat` is
+  local-alert correlation not "AI-powered"; `check_ioc_reputation` is local sightings not an
+  external feed; the "log collector stats" tool returns analysisd stats; `block` `duration` is
+  advisory, governed by the manager `<timeout>`).
+- **Redis session store no longer wiped on shutdown** — a single pod restart previously 404'd every
+  other instance's live sessions; TTL handles expiry.
+
+## Deferred (tracked, not addressed)
+
+These need larger design changes or are lower-impact; grouped for follow-up.
 
 - **MCP protocol semantics:** `/sse` does not emit the legacy `event: endpoint` frame a true
   2024-11-05 HTTP+SSE client expects; session handler state (capabilities/negotiated version) is
   not persisted after `initialize`; initialization is tracked but not enforced. Multi-worker
   deployments should prefer stateless modern `_meta` requests until session persistence lands.
-- **Redis session store:** shutdown `clear()` wipes the shared store (one pod restart 404s every
-  instance); `get()` returns a copy vs a live dict (write-through divergence vs in-memory);
-  `cleanup_expired` is a no-op. Redis mode is opt-in.
+- **Redis session store:** `get()` returns a copy vs a live dict (write-through divergence vs
+  in-memory); `cleanup_expired` is a no-op. Redis mode is opt-in.
 - **Active Response semantics:** `!host-isolation`/`!kill-process`/`!quarantine`/`!enable-account`
   are not stock Wazuh scripts — these tools require operator-deployed AR scripts (the zero-affected
-  guard fails safe, but descriptions overstate out-of-box capability); `duration` on block/firewall
-  is advisory only (expiry needs manager `<timeout>` config); the verification tools' free-text
-  `"X AND Y"` queries don't match under `simple_query_string`.
-- **Read-tool scoping/semantics:** `get_iso27001_dashboard`/`perform_risk_assessment` apply
-  `agent_id` only to part of their data; `get_top_security_threats` score saturates (chatty low-sev
-  rules outrank targeted high-sev); `get_sca_policy_checks` counts N/A checks in the denominator.
+  guard fails safe, and descriptions now note this).
+- **Read-tool scoping:** `get_iso27001_dashboard`/`perform_risk_assessment` apply `agent_id` only to
+  part of their data.
 - **Deploy:** `wazuh-mcp-server` is not yet published to PyPI (README `pip install` 404s until the
   `PUBLISH_PYPI` gate is enabled); the documented `--scale` command conflicts with `container_name`;
   Dockerfile pre-`FROM` ARGs leave OCI version/created labels empty; the healthcheck hardcodes

--- a/src/wazuh_mcp_server/api/wazuh_client.py
+++ b/src/wazuh_mcp_server/api/wazuh_client.py
@@ -1266,9 +1266,15 @@ class WazuhClient:
         for rule_id, data in rule_data.items():
             level = data["level"]
             count = data["count"]
-            # Score: level weight * log(count) * affected_systems_factor
             affected_count = len(data["affected_agents"])
-            threat_score = min(100, int(level * 5 * math.log2(count + 1) * (1 + 0.1 * affected_count)))
+            # Normalize each factor to 0..1 and cap BEFORE combining, then weight severity
+            # highest. The old `min(100, level*5*log2(count)*...)` capped the *product*, so a
+            # chatty level-3 rule (1000 hits) saturated to 100 and outranked a level-15 targeted
+            # attack (1 hit → 75). Severity must dominate the ranking.
+            severity = level / 15.0  # Wazuh max rule level is 15
+            volume = min(math.log2(count + 1), 6.0) / 6.0  # saturates ~63 events
+            spread = min(affected_count, 10) / 10.0
+            threat_score = int(100 * (0.6 * severity + 0.25 * volume + 0.15 * spread))
 
             threats.append(
                 {
@@ -1602,7 +1608,10 @@ class WazuhClient:
                 "passed": len(passed),
                 "failed": len(failed),
                 "not_applicable": len(not_applicable),
-                "score": int(len(passed) / len(checks) * 100) if checks else 0,
+                # Score over APPLICABLE checks only (passed + failed). Including "not applicable"
+                # in the denominator understated a 100%-passing policy — 50 passed + 50 N/A read
+                # as 50%. N/A checks are reported separately above.
+                "score": int(len(passed) / (len(passed) + len(failed)) * 100) if (passed or failed) else 0,
                 "failed_checks": [
                     {
                         "id": c.get("id"),
@@ -2552,21 +2561,32 @@ class WazuhClient:
     # Verification Tools
     # =========================================================================
 
-    async def check_blocked_ip(self, ip_address: str, agent_id: str = None) -> Dict[str, Any]:
-        """Check if IP is blocked by searching active response alerts via Elasticsearch."""
+    async def check_blocked_ip(self, ip_address: str, agent_id: str = None, window: str = "now-24h") -> Dict[str, Any]:
+        """Check whether an IP was recently blocked, via active-response alerts on the Indexer.
+
+        Uses STRUCTURED filters (data.srcip + the active_response rule group) rather than a
+        free-text query. A free-text ``'"ip" AND "firewall-drop"'`` routes through the Indexer's
+        simple_query_string, where AND is a literal term and default_operator=AND then requires the
+        token "and" in the document — which AR alerts don't contain — so it reliably matched
+        nothing and reported a blocked IP as not blocked. Bounded to a recent window so a block
+        that already expired long ago isn't reported as still active.
+        """
         if not self._indexer_client:
             raise IndexerNotConfiguredError()
-        # Use Elasticsearch query_string to search for both the IP and firewall-drop.
-        # Scope to the requested agent when given, instead of ignoring agent_id and
-        # reporting a fleet-wide block status for a per-agent question.
-        query = f'"{ip_address}" AND "firewall-drop"'
-        result = await self._indexer_client.get_alerts(limit=50, query_text=query, agent_id=agent_id)
+        result = await self._indexer_client.get_alerts(
+            limit=50,
+            srcip=ip_address,
+            rule_groups=["active_response"],
+            agent_id=agent_id,
+            timestamp_start=window,
+        )
         _, total, _ = self._alerts_and_total(result)
         return {
             "data": {
                 "ip_address": ip_address,
                 "agent_id": agent_id,
                 "scope": "agent" if agent_id else "fleet",
+                "window": window,
                 "blocked": total > 0,
                 "matching_alerts": total,
             }
@@ -2580,12 +2600,21 @@ class WazuhClient:
             raise ValueError(f"Agent {agent_id} not found")
         agent = agents[0]
         status = agent.get("status")
-        # Check alert history for isolation commands if indexer is available
+        # Look for a recent host-isolation active-response alert for THIS agent, regardless of
+        # connection status. Wazuh host-isolation deliberately preserves the agent↔manager link,
+        # so a correctly isolated host stays "active" — keying isolation off "disconnected" (as
+        # before) both missed real isolations and misfired on merely-offline agents. The old
+        # free-text 'host-isolation AND {id}' query also matched nothing under simple_query_string.
         isolation_confirmed = False
-        if self._indexer_client and status == "disconnected":
+        if self._indexer_client:
             try:
-                query = f'"host-isolation" AND "{agent_id}"'
-                alerts = await self._indexer_client.get_alerts(limit=5, query_text=query)
+                alerts = await self._indexer_client.get_alerts(
+                    limit=5,
+                    agent_id=agent_id,
+                    rule_groups=["active_response"],
+                    query_text="isolation",
+                    timestamp_start="now-24h",
+                )
                 items = alerts.get("data", {}).get("affected_items", [])
                 isolation_confirmed = len(items) > 0
             except Exception:
@@ -2594,20 +2623,35 @@ class WazuhClient:
             "data": {
                 "agent_id": agent_id,
                 "status": status,
-                "possibly_isolated": status == "disconnected",
                 "isolation_confirmed": isolation_confirmed,
                 "name": agent.get("name"),
-                "note": "A disconnected agent may be isolated or simply offline. "
-                "Check isolation_confirmed for active response evidence.",
+                "note": "isolation_confirmed reflects a recent host-isolation active-response alert. "
+                "Connection status is not a reliable isolation signal — a correctly isolated host "
+                "keeps its manager link. Verify on the host for a definitive answer.",
             }
         }
 
     async def check_process(self, agent_id: str, process_id: int) -> Dict[str, Any]:
-        """Check if a process is still running on an agent."""
-        result = await self._request("GET", f"/syscollector/{agent_id}/processes", params={"limit": 500})
+        """Check if a process is still running on an agent (syscollector inventory)."""
+        # Query the specific PID rather than paging the first 500 processes — on a busy host a
+        # still-running target beyond the first page would otherwise be reported as killed.
+        result = await self._request(
+            "GET", f"/syscollector/{agent_id}/processes", params={"q": f"pid={int(process_id)}", "limit": 1}
+        )
         processes = result.get("data", {}).get("affected_items", [])
         running = any(str(p.get("pid")) == str(process_id) for p in processes)
-        return {"data": {"agent_id": agent_id, "process_id": process_id, "running": running}}
+        # Syscollector is a periodic inventory, not live — surface the scan time so the caller
+        # can judge freshness (a just-killed PID may still appear until the next scan).
+        scan_time = processes[0].get("scan", {}).get("time") if processes else None
+        return {
+            "data": {
+                "agent_id": agent_id,
+                "process_id": process_id,
+                "running": running,
+                "inventory_scan_time": scan_time,
+                "note": "Based on periodic syscollector inventory, not a live process list.",
+            }
+        }
 
     async def check_user_status(self, agent_id: str, username: str) -> Dict[str, Any]:
         """Check user account status by searching active response alerts via Elasticsearch."""
@@ -2615,18 +2659,27 @@ class WazuhClient:
         enable_evidence = False
         if self._indexer_client:
             try:
-                # Search for disable-account events for this user and agent
-                disable_query = f'"disable-account" AND "{username}" AND "{agent_id}"'
-                disable_result = await self._indexer_client.get_alerts(limit=5, query_text=disable_query)
-                disable_evidence = len(disable_result.get("data", {}).get("affected_items", [])) > 0
-
-                # Search for enable-account events
-                enable_query = f'"enable-account" AND "{username}" AND "{agent_id}"'
-                enable_result = await self._indexer_client.get_alerts(limit=5, query_text=enable_query)
-                enable_evidence = len(enable_result.get("data", {}).get("affected_items", [])) > 0
+                # Fetch recent active-response alerts mentioning this user on this agent (the
+                # username goes through as a single simple_query_string term; the old
+                # '"disable-account" AND "user" AND "id"' form matched nothing), then classify
+                # each by its rule text. Free-text AND is not a boolean operator on this backend.
+                result = await self._indexer_client.get_alerts(
+                    limit=25,
+                    agent_id=agent_id,
+                    rule_groups=["active_response"],
+                    query_text=username,
+                    timestamp_start="now-24h",
+                )
+                items = result.get("data", {}).get("affected_items", [])
+                for alert in items:
+                    blob = str(alert.get("rule", {}).get("description", "")).lower()
+                    if "disable" in blob:
+                        disable_evidence = True
+                    if "enable" in blob:
+                        enable_evidence = True
             except Exception:
                 pass
-        # Most recent action takes precedence
+        # Heuristic: presence of a disable event without a later enable. Not order-aware.
         likely_disabled = disable_evidence and not enable_evidence
         return {
             "data": {
@@ -2644,8 +2697,19 @@ class WazuhClient:
         # FIM data is per-agent: GET /syscheck/{agent_id}. GET /syscheck (no id) is 405.
         result = await self._request("GET", f"/syscheck/{agent_id}", params={"q": f"file={file_path}"})
         events = result.get("data", {}).get("affected_items", [])
-        quarantined = any(e.get("type") == "deleted" or "quarantine" in str(e) for e in events)
-        return {"data": {"agent_id": agent_id, "file_path": file_path, "quarantined": quarantined}}
+        # The FIM query is already scoped to this exact path, so a 'deleted' event for it is the
+        # quarantine signal (Wazuh's quarantine AR removes the file from its original location).
+        # The previous `"quarantine" in str(e)` matched any path whose stringified event merely
+        # contained the substring "quarantine" — a false positive on any file under such a path.
+        quarantined = any(e.get("type") == "deleted" for e in events)
+        return {
+            "data": {
+                "agent_id": agent_id,
+                "file_path": file_path,
+                "quarantined": quarantined,
+                "note": "Inferred from a FIM deletion of the exact path; verify the quarantine store on the host.",
+            }
+        }
 
     # =========================================================================
     # Rollback Tools

--- a/src/wazuh_mcp_server/server.py
+++ b/src/wazuh_mcp_server/server.py
@@ -592,12 +592,13 @@ async def lifespan(app: FastAPI):
         auth_manager.tokens.clear()
         logger.info("Authentication tokens cleared")
 
-        # Clear sessions with proper cleanup
-        await sessions.clear()
-        # Close session store backend (e.g., Redis connection)
+        # Do NOT clear the session store on shutdown. In-memory sessions vanish with the process
+        # anyway, and a shared Redis store is the whole point of multi-instance deployments —
+        # wiping it here would 404 every OTHER instance's live sessions on a single pod restart or
+        # rolling deploy. Redis TTL handles expiry. Just close this instance's backend connection.
         if hasattr(sessions._store, "close"):
             await sessions._store.close()
-        logger.info("Sessions cleared")
+        logger.info("Session store backend closed (sessions preserved for other instances)")
 
         # Close Wazuh clients (all configured clusters) to release HTTP connections
         await cluster_registry.close()
@@ -1962,7 +1963,7 @@ async def handle_tools_list(params: Dict[str, Any], session: MCPSession) -> Dict
         # Security Analysis Tools (7 tools)
         {
             "name": "analyze_security_threat",
-            "description": "Analyze a security threat indicator using AI-powered analysis",
+            "description": "Analyze a security threat indicator by correlating it against recent Wazuh alert history",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -1977,7 +1978,7 @@ async def handle_tools_list(params: Dict[str, Any], session: MCPSession) -> Dict
         },
         {
             "name": "check_ioc_reputation",
-            "description": "Check reputation of an Indicator of Compromise (IoC)",
+            "description": "Count local Wazuh alert sightings of an indicator (IP/domain/hash). This reflects local activity, not an external threat-intel reputation feed; zero sightings means 'not seen locally', not 'known clean'.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -2211,7 +2212,7 @@ async def handle_tools_list(params: Dict[str, Any], session: MCPSession) -> Dict
         },
         {
             "name": "get_wazuh_log_collector_stats",
-            "description": "Get Wazuh log collector statistics",
+            "description": "Get Wazuh manager analysisd statistics (event decoding/rule matching throughput)",
             "inputSchema": {"type": "object", "properties": {}, "required": []},
         },
         {
@@ -2252,7 +2253,7 @@ async def handle_tools_list(params: Dict[str, Any], session: MCPSession) -> Dict
                         "type": "integer",
                         "minimum": 0,
                         "default": 0,
-                        "description": "Block duration in seconds (0 = permanent)",
+                        "description": "Block duration in seconds (0 = permanent). Advisory only: actual expiry is governed by the manager's active-response <timeout> configuration, not per-call.",
                     },
                     "agent_id": {
                         "type": "string",
@@ -2923,7 +2924,7 @@ async def handle_tools_call(params: Dict[str, Any], session: MCPSession) -> Dict
         elif tool_name == "get_wazuh_log_collector_stats":
             result = await wazuh_client.get_log_collector_stats()
             _success = True
-            return _tool_result(f"Log Collector Statistics:\n{json.dumps(result, indent=2, default=str)}")
+            return _tool_result(f"Analysisd Statistics:\n{json.dumps(result, indent=2, default=str)}")
 
         elif tool_name == "search_wazuh_manager_logs":
             query = validate_query(arguments.get("query"), required=True)

--- a/tests/integration/test_audit_hardening.py
+++ b/tests/integration/test_audit_hardening.py
@@ -243,6 +243,90 @@ class TestManagerAgentGuard:
         _guard_manager_agent("000", "wazuh_isolate_host")  # no raise when explicitly opted in
 
 
+class _FakeIndexer:
+    """Captures get_alerts kwargs and returns a canned result."""
+
+    def __init__(self, items=None):
+        self.calls = []
+        self._items = items or []
+
+    async def get_alerts(self, **kwargs):
+        self.calls.append(kwargs)
+        return {"data": {"affected_items": self._items, "total_affected_items": len(self._items)}}
+
+
+class TestVerificationQueries:
+    @pytest.mark.asyncio
+    async def test_check_blocked_ip_uses_structured_filters(self):
+        client = _client()
+        fake = _FakeIndexer(items=[{"rule": {"groups": ["active_response"]}}])
+        client._indexer_client = fake
+        out = await client.check_blocked_ip("1.2.3.4", agent_id="001")
+        call = fake.calls[0]
+        # Structured filters, not a free-text 'AND' query that matches nothing.
+        assert call.get("srcip") == "1.2.3.4"
+        assert call.get("rule_groups") == ["active_response"]
+        assert call.get("agent_id") == "001"
+        assert "query_text" not in call or "AND" not in str(call.get("query_text"))
+        assert call.get("timestamp_start")  # bounded window
+        assert out["data"]["blocked"] is True
+
+    @pytest.mark.asyncio
+    async def test_check_process_queries_specific_pid(self):
+        client = _client()
+        captured = {}
+
+        async def fake_request(method, path, params=None):
+            captured["path"] = path
+            captured["params"] = params
+            return {"data": {"affected_items": [{"pid": 4242, "scan": {"time": "t"}}]}}
+
+        client._request = fake_request
+        out = await client.check_process("001", 4242)
+        assert captured["params"].get("q") == "pid=4242"  # not a 500-row page scan
+        assert out["data"]["running"] is True
+        assert out["data"]["inventory_scan_time"] == "t"
+
+    @pytest.mark.asyncio
+    async def test_check_file_quarantine_no_substring_false_positive(self):
+        client = _client()
+
+        async def fake_request(method, path, params=None):
+            # A modified (not deleted) event on a path that merely contains "quarantine".
+            return {"data": {"affected_items": [{"type": "modified", "path": "/var/quarantine/keep.txt"}]}}
+
+        client._request = fake_request
+        out = await client.check_file_quarantine("001", "/var/quarantine/keep.txt")
+        assert out["data"]["quarantined"] is False
+
+
+class TestScaScore:
+    @pytest.mark.asyncio
+    async def test_na_checks_excluded_from_denominator(self):
+        client = _client()
+
+        async def fake_request(method, path, params=None):
+            checks = [{"result": "passed"}] * 50 + [{"result": "not applicable"}] * 50
+            return {"data": {"affected_items": checks}}
+
+        client._request = fake_request
+        out = await client.get_sca_policy_checks("001", "cis_debian10")
+        assert out["data"]["score"] == 100  # 50 passed / 50 applicable, not / 100
+
+
+class TestThreatScoreRanking:
+    @pytest.mark.asyncio
+    async def test_targeted_high_severity_outranks_chatty_low(self):
+        client = _client()
+        alerts = [{"rule": {"id": "noise", "level": 3, "description": "x"}, "agent": {"id": "1"}}] * 1000 + [
+            {"rule": {"id": "apt", "level": 15, "description": "y"}, "agent": {"id": "2"}}
+        ]
+        client._indexer_client = _FakeIndexer(items=alerts)
+        out = await client.get_top_security_threats(limit=10, time_range="24h")
+        threats = {t["rule_id"]: t["threat_score"] for t in out["data"]["threats"]}
+        assert threats["apt"] > threats["noise"], threats
+
+
 class TestCircuitBreakerCancellation:
     @pytest.mark.asyncio
     async def test_half_open_trial_gate_released_on_cancellation(self):


### PR DESCRIPTION
Follow-up to #105, working the deferred correctness findings from the audit.

### Active-Response verification tools were reporting wrong answers
The `check_*` tools that confirm a state-changing action built free-text `'"1.2.3.4" AND "firewall-drop"'` queries. These route through the Indexer's `simple_query_string`, where `AND` is a literal search term and `default_operator=AND` then requires the token "and" in the document — which AR alerts don't contain — so they **reliably matched nothing and reported a blocked IP / isolated host / disabled user as *not* actioned**. Now they use structured `srcip`/`rule_groups`/`agent_id` filters with a bounded time window.

- `check_agent_isolation` no longer equates "disconnected" with "isolated" — Wazuh host-isolation deliberately preserves the manager link, so the old heuristic both missed real isolations and misfired on merely-offline agents.
- `check_process` queries the specific PID instead of paging the first 500 (a running process beyond the page was reported killed) and surfaces the inventory scan time.
- `check_file_quarantine` keys off a FIM deletion of the exact path, not a substring match over the stringified event (which false-positived on any path containing "quarantine").

### Reporting correctness
- `get_sca_policy_checks` scores over applicable checks only — 50 passed + 50 N/A previously read as 50%.
- `get_top_security_threats` uses a severity-weighted score that no longer saturates, so a chatty level-3 rule can't outrank a targeted level-15 attack (verified by a ranking test).

### Tool descriptions
Corrected the LLM-facing descriptions that overstated capability (`analyze_security_threat`, `check_ioc_reputation`, log-collector stats, `block` duration).

### Session store
Don't wipe the store on shutdown — a single pod restart previously 404'd every other instance's live Redis sessions; TTL handles expiry.

+7 regression tests (structured-query assertions, PID query, N/A denominator, threat ranking); full suite **266 passing**, lint clean, boots and serves 55 tools. `docs/AUDIT_FINDINGS.md` updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved threat scoring by prioritizing severity and affected-agent spread.
  * Corrected SCA scoring to exclude not-applicable checks.
  * Improved vulnerability, quarantine, process, and active-response verification accuracy.
  * Preserved shared sessions when shutting down an instance.
  * Clarified tool descriptions and analysis results.

* **Documentation**
  * Updated audit documentation with resolved verification and scoring findings, while retaining outstanding issues.

* **Tests**
  * Added regression coverage for verification queries, SCA scoring, and threat ranking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->